### PR TITLE
Update install_gfortran.md

### DIFF
--- a/source/learn/os_setup/install_gfortran.md
+++ b/source/learn/os_setup/install_gfortran.md
@@ -7,9 +7,9 @@ GFortran is the name of the [GNU Fortran project](https://gcc.gnu.org/fortran/).
 Three sources provide quick and easy way to install GFortran compiler on Windows:
 
 1. [http://www.equation.com](http://www.equation.com/servlet/equation.cmd?fa=fortran), provides 32 and 64-bit x86
-   executables of the latest (10.2) gcc-version.
-2. [TDM GCC](https://jmeubank.github.io/tdm-gcc/articles/2020-03/9.2.0-release), provides 32 and 64-bit x86 executables of the 9.2 gcc-version.
-3. [MinGW-w64](http://mingw-w64.org/doku.php/download/mingw-builds) provides a 64-bit x86 executable of the 8.1.0 gcc-version.
+   executables for GCC version 12.1.
+2. [TDM GCC](https://jmeubank.github.io/tdm-gcc/articles/2021-05/10.3.0-release), provides 32 and 64-bit x86 executables for GCC version 10.3.
+3. [MinGW-w64](https://www.mingw-w64.org/downloads/#mingw-builds) provides a 64-bit x86 executable for GCC version 12.2.
 
 In all the above choices, the process is straightforward—just download the installer and follow the installation wizard.
 
@@ -17,8 +17,8 @@ In all the above choices, the process is straightforward—just download the ins
 
 For those familiar with a unix-like development environment, several emulation options are available on Windows each of which provide packages for gfortran:
 
-- **Cygwin:** A runtime environment that provides POSIX compatibility to Windows;
-- **MSYS2:** A collection of Unix-like development tools, based on modern Cygwin and MinGW-w64;
+- **Cygwin:** A runtime environment that provides POSIX compatibility to Windows.
+- **MSYS2:** A collection of Unix-like development tools, based on modern Cygwin and MinGW-w64.
 - **Windows Subsystem for Linux (WSL):** An official compatibility layer for running Linux binary executables on Windows. With [Windows Subsystem for Linux GUI](https://github.com/microsoft/wslg) one can run text editors and other graphical programs.
 
 All of the above approaches provide access to common shells such as bash and development tools including GNU coreutils, Make, CMake, autotools, git, grep, sed, awk, ssh, etc.
@@ -39,7 +39,7 @@ If nothing is returned then gfortran is not installed.
 To install gfortran type:
 
 ```bash
-sudo apt-get install gfortran
+sudo apt install gfortran
 ```
 
 to check what version was installed type:
@@ -48,13 +48,13 @@ to check what version was installed type:
 gfortran --version
 ```
 
-You can install multiple versions up to version 9 by typing the version number immediately after "gfortran", e.g.:
+You can install multiple versions up to version 10 (on Ubuntu 22.04) by typing the version number immediately after "gfortran", e.g.:
 
 ```bash
-sudo apt-get install gfortran-7
+sudo apt install gfortran-8
 ```
 
-To install the latest version 10 you need first to add / update the following repository and then install:
+To install newer versions on older Ubuntu releases, you will first need to add the following repository, update, and then install:
 
 ```bash
 sudo add-apt-repository ppa:ubuntu-toolchain-r/test
@@ -62,21 +62,21 @@ sudo apt update
 sudo apt install gfortran-10
 ```
 
-Finally, you can switch between different versions or set the default one with the **update-alternatives** ([see manpage](https://manpages.ubuntu.com/manpages/trusty/man8/update-alternatives.8.html#:~:text=update%2Dalternatives%20creates%2C%20removes%2C,system%20at%20the%20same%20time.)). There are many online tutorials on how to use this feature. A well structured one using as an example C and C++ can be found [here](https://linuxconfig.org/how-to-switch-between-multiple-gcc-and-g-compiler-versions-on-ubuntu-20-04-lts-focal-fossa), you can apply the same logic by replacing either `gcc` or `g++` with `gfortran`.
+Finally, you can switch between different versions or set the default one with the **update-alternatives** ([see manpage](https://manpages.ubuntu.com/manpages/jammy/en/man1/update-alternatives.1.html)). There are many online tutorials on how to use this feature. A well structured one using as an example C and C++ can be found [here](https://linuxconfig.org/how-to-switch-between-multiple-gcc-and-g-compiler-versions-on-ubuntu-22-04-lts-jammy-jellyfish), you can apply the same logic by replacing either `gcc` or `g++` with `gfortran`.
 
-### RPM-based (Red Hat Linux, CentOS, Fedora, openSuse, Mandrake Linux)
+### RPM-based (Red Hat Enterprise Linux, CentOS, Fedora, openSUSE)
 
 ```bash
 sudo yum install gcc-gfortran
 ```
 
-Since Fedora 22, `dnf` is the default package manager for Fedora:
+Since Fedora 22 and Red Hat Enterprise Linux 8, `dnf` is the default package manager for Fedora:
 
 ```bash
 sudo dnf install gcc-gfortran
 ```
 
-### Arch-based (Arch Linux, Antergos, Manjaro, etc...)
+### Arch-based (Arch Linux, EndeavourOS, Manjaro, etc...)
 
 ```bash
 sudo pacman -S gcc-fortran


### PR DESCRIPTION
* Update links for latest provided GCC versions.
* Updated links for Ubuntu.
* Cleaned up language a bit.
* EndeavourOS is the spiritual successor to Antergos.
* "In 2003, Red Hat discontinued the Red Hat Linux line in favor of Red Hat Enterprise Linux (RHEL)." - Wikipedia page
* Mandrake Linux has not had a new release since 2011 and is no longer a popular RPM distribution.