### PR TITLE
Link to LFortran WASM compiler #46 

### DIFF
--- a/source/compilers.md
+++ b/source/compilers.md
@@ -35,9 +35,7 @@ based on the NVIDIA/PGI commercial compiler.
 
 [LFortran](https://lfortran.org) is a modern, interactive, LLVM-based Fortran
 compiler.
-
-[LFortran WASM Compiler](https://dev.lfortran.org/) is a statically served, WASM based LFortran Compiler for running the code in the web browsers.
-
+Also available online at [dev.lfortran.org](https://dev.lfortran.org/) using a statically served, WASM based LFortran Compiler for running code in web browsers.
 <p style="font-size:24px;color:#734f96;"><b>Commercial compilers</b></p>
 
 <h4> <b> Intel</b></h4>

--- a/source/compilers.md
+++ b/source/compilers.md
@@ -36,6 +36,8 @@ based on the NVIDIA/PGI commercial compiler.
 [LFortran](https://lfortran.org) is a modern, interactive, LLVM-based Fortran
 compiler.
 
+[LFortran WASM Compiler](https://dev.lfortran.org/) is a statically served, WASM based LFortran Compiler for running the code in the web browsers.
+
 <p style="font-size:24px;color:#734f96;"><b>Commercial compilers</b></p>
 
 <h4> <b> Intel</b></h4>


### PR DESCRIPTION
This PR is to add the  LFortran WASM compiler to the compilers section of the fortran-lang.org , we should reference the LFortran WASM compiler to make it more discoverable for visitors.  please refer #46 for more information.

Please provide your suggestions regarding the current description of the compiler and location of the link in the webpage.

Thanks and Regards,
Henil Shalin Panchal

CC @awvwgk @certik @Shaikh-Ubaid 