### PR TITLE
Fix year in the copyright statement

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2022 fortran-lang.org Contributors
+Copyright (c) 2020-2022 fortran-lang.org Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/source/conf.py
+++ b/source/conf.py
@@ -45,7 +45,7 @@ with open(data_files["contributors"], "r", encoding="utf-8") as f:
 # -- Project information -----------------------------------------------------
 
 project = "Fortran-lang.org website"
-copyright = "2022, Fortran Community"
+copyright = "2020-2022, Fortran Community"
 author = "Fortran Community"
 
 # The full version, including alpha/beta/rc tags


### PR DESCRIPTION
The current copyright statement states the year 2022, but most of the content was created in 2020 and 2021. This PR updates the copyright years to 2020-2022.