### PR TITLE
Fixes two typos in the Learn page

### DIFF
--- a/data/learning.yml
+++ b/data/learning.yml
@@ -294,7 +294,6 @@ reference-links:
 
   - name: "WG5: International Fortran Standards Committee"
     url: https://wg5-fortran.org/
-    description:
 
   - name: "Scivision Fortran 2018 Examples"
     url: https://github.com/scivision/fortran2018-examples
@@ -379,7 +378,7 @@ reference-courses:
     description: >-
       by Ian Foster,
       contains descriptions of several non-standard Fortran dialects
-      like Fortran M and High Performance Fortran)
+      like Fortran M and High Performance Fortran
 
   - name: "Parallel programming with Fortran 2008 and 2018 coarrays"
     url: https://coarrays.sourceforge.io/doc.html


### PR DESCRIPTION
- Concerning WG5, as the `description:` field is void, the "None" string appeared on the webpage. I have removed that field to avoid that.
- I have deleted a ")" without a corresponding "("