### PR TITLE
Add REDUCE(3f), and miscellaneous errata and style changes

### DIFF
--- a/source/learn/intrinsics/_pages/ABS.md
+++ b/source/learn/intrinsics/_pages/ABS.md
@@ -17,7 +17,7 @@
    where the TYPE and KIND is determined by the type and type attributes
    of **a**, which may be any _real_, _integer_, or _complex_ value.
 
-   If the type of **a** is _cmplx_ the type returned will be _real_
+   If the type of **a** is _complex_ the type returned will be _real_
    with the same kind as the _real_ part of the input value.
 
    Otherwise the returned type will be the same type as **a**.
@@ -63,29 +63,28 @@ character(len=*),parameter :: &
  frmt =  '(1x,a15,1x," In: ",g0,            T51," Out: ",g0)', &
  frmtc = '(1x,a15,1x," In: (",g0,",",g0,")",T51," Out: ",g0)'
 integer,parameter :: dp=kind(0.0d0)
-integer,parameter :: sp=kind(0.0)
 
+  ! any integer, real, or complex type
     write(*, frmt)  'integer         ',  i, abs(i)
     write(*, frmt)  'real            ',  x, abs(x)
     write(*, frmt)  'doubleprecision ', rr, abs(rr)
     write(*, frmtc) 'complex         ',  z, abs(z)
-    !
-    !
-    write(*, *)
-    write(*, *) 'abs is elemental: ', abs([20,  0,  -1,  -3,  100])
-    write(*, *)
+
+  ! any value whose positive value is representable
+  ! A dusty corner is that abs(-huge(0)-1) would input a representable
+  ! negative value but result in a positive value out of range.
     write(*, *) 'abs range test : ', abs(huge(0)), abs(-huge(0))
     write(*, *) 'abs range test : ', abs(huge(0.0)), abs(-huge(0.0))
     write(*, *) 'abs range test : ', abs(tiny(0.0)), abs(-tiny(0.0))
 
-    write(*, *) 'returned real kind:', cmplx(30.0_dp,40.0_dp,kind=dp), &
-                                  kind(cmplx(30.0_dp,40.0_dp,kind=dp))
-    write(*, *) 'returned real kind:', cmplx(30.0_dp,40.0_dp),&
-                                  kind(cmplx(30.0_dp,40.0_dp))
-    write(*, *) 'returned real kind:', cmplx(30.0_sp,40.0_sp),&
-                                  kind(cmplx(30.0_sp,40.0_sp))
+  ! elemental
+    write(*, *) 'abs is elemental: ', abs([20,  0,  -1,  -3,  100])
 
-    write(*, *)
+  ! complex input produces real output  
+    write(*, *)  cmplx(30.0,40.0)
+
+  ! the returned value for complex input can be thought of as the
+  ! distance from the origin <0,0>
     write(*, *) 'distance of <XX,YY> from zero is', &
                & distance(30.0_dp,40.0_dp)
 
@@ -99,27 +98,21 @@ integer,parameter :: sp=kind(0.0)
        ! See cmplx(3).
        distance=abs( cmplx(x,y,kind=dp) )
     end function distance
+
 end program demo_abs
 ```
-
-Results:
-
+  Results:
 ```text
-    integer          In: -1                        Out: 1
-    real             In: -1.00000000               Out: 1.00000000
-    doubleprecision  In: -45.780000000000001       Out: 45.780000000000001
-    complex          In: (-3.00000000,-4.00000000) Out: 5.00000000
-
-    abs is elemental:     20     0     1     3   100
-
+    integer          In: -1                     Out: 1
+    real             In: -1.000000              Out: 1.000000
+    doubleprecision  In: -45.78000000000000     Out: 45.78000000000000
+    complex          In: (-3.000000,-4.000000)  Out: 5.000000
     abs range test :   2147483647  2147483647
-    abs range test :    3.40282347E+38   3.40282347E+38
-    abs range test :    1.17549435E-38   1.17549435E-38
-    returned real kind: (30.000000000000000,40.000000000000000) 8
-    returned real kind: (30.0000000,40.0000000) 4
-    returned real kind: (30.0000000,40.0000000) 4
-
-    distance of <XX,YY> from zero is   50.000000000000000
+    abs range test :   3.4028235E+38  3.4028235E+38
+    abs range test :   1.1754944E-38  1.1754944E-38
+    abs is elemental: 20 0 1 3 100
+    (30.00000,40.00000)
+    distance of <XX,YY> from zero is   50.0000000000000     
 ```
 
 ### **Standard**

--- a/source/learn/intrinsics/_pages/ADJUSTR.md
+++ b/source/learn/intrinsics/_pages/ADJUSTR.md
@@ -38,9 +38,7 @@ Sample program:
 ```fortran
 program demo_adjustr
 implicit none
-integer :: right
 character(len=20) :: str = ' sample string '
-character(len=:),allocatable :: str2
    ! print a short number line
    write(*,'(a)')repeat('1234567890',5)
 

--- a/source/learn/intrinsics/_pages/ALL.md
+++ b/source/learn/intrinsics/_pages/ALL.md
@@ -46,8 +46,8 @@ where the **dim** dimension is elided.
 3.  Result Characteristics. The result is of type _logical_ with the
     same kind type parameter as **mask**. It is scalar if **dim**
     is absent or **n = 1**; otherwise, the result has rank **n - 1**
-    and shape **\[d1 , d2 , . . . , dDIM-1 , dDIM+1 , . . . , dn \]**
-    where **\[d1 , d2 , . . . , dn \]** is the shape of **mask**.
+    and shape **\[d1, d2, . . ., dDIM-1, dDIM+1, . . ., dn \]**
+    where **\[d1, d2, . . ., dn \]** is the shape of **mask**.
 
 4.  Result Value.
 
@@ -59,10 +59,10 @@ where the **dim** dimension is elided.
 
     Case (ii):
     : If **mask** has rank one, **all(mask,dim)** is equal to
-    **all(mask)**. Otherwise, the value of element **(s1 , s2 ,
-    . . . , sdim-1 , sdim+1 , . . . , sn )** of all **(mask,
-    dim)** is equal to **all(mask (s1 , s2 , . . . , sdim-1 ,
-    :, sdim+1 , . . . , sn ))**.
+    **all(mask)**. Otherwise, the value of element **(s1, s2,
+    . . ., sdim-1, sdim+1, . . ., sn )** of all **(mask,
+    dim)** is equal to **all(mask (s1, s2, . . ., sdim-1,
+    :, sdim+1, . . ., sn ))**.
 
 ### **Examples**
 

--- a/source/learn/intrinsics/_pages/ALL.md
+++ b/source/learn/intrinsics/_pages/ALL.md
@@ -117,11 +117,9 @@ Case (ii):
    then all(B /= C, DIM = 1) is
 
       [true, false, false]
-```
 
-and **all(B /= C, DIM = 2)** is
+   and **all(B /= C, DIM = 2)** is
 
-```
         [false, false].
 ```
 

--- a/source/learn/intrinsics/_pages/BGT.md
+++ b/source/learn/intrinsics/_pages/BGT.md
@@ -35,8 +35,8 @@ Fortran 2008 and later
 
 ### **See Also**
 
-[**bge**(3),](BGE),
-[**ble**(3),](BLE),
+[**bge**(3)](BGE),
+[**ble**(3)](BLE),
 [**blt**(3)](BLT)
 
 ###### fortran-lang intrinsic descriptions

--- a/source/learn/intrinsics/_pages/BIT_SIZE.md
+++ b/source/learn/intrinsics/_pages/BIT_SIZE.md
@@ -67,4 +67,4 @@ Typical Results:
 
 Fortran 95 and later
 
-###### fortran-lang intrinsic descriptions (license MIT) @urbanjost
+###### fortran-lang intrinsic descriptions (license: MIT) @urbanjost

--- a/source/learn/intrinsics/_pages/BIT_SIZE.md
+++ b/source/learn/intrinsics/_pages/BIT_SIZE.md
@@ -40,7 +40,6 @@ program demo_bit_size
 use,intrinsic :: iso_fortran_env, only : int8, int16, int32, int64
 implicit none
 integer(kind=int64)          :: answer
-integer                      :: ilen
 character(len=*),parameter   :: fmt='(*(g0,1x))'
     write(*,fmt)'default integer size is',bit_size(0),'bits'
     write(*,fmt)bit_size(bit_size(0_int8)), 'which is kind=',kind(0_int8)

--- a/source/learn/intrinsics/_pages/BLE.md
+++ b/source/learn/intrinsics/_pages/BLE.md
@@ -32,8 +32,8 @@ Fortran 2008 and later
 
 ### **See Also**
 
-[**bge**(3),](BGE),
-[**bgt**(3),](BGT),
+[**bge**(3)](BGE),
+[**bgt**(3)](BGT),
 [**blt**(3)](BLT)
 
 ###### fortran-lang intrinsic descriptions

--- a/source/learn/intrinsics/_pages/CMPLX.md
+++ b/source/learn/intrinsics/_pages/CMPLX.md
@@ -135,7 +135,7 @@ complex(kind=dp) :: z8
    ! NOTE:
    ! The following is intuitive and works without calling cmplx(3)
    ! but does not work for variables just constants
-   z8 = (1.2345678901234567d0 , 1.2345678901234567d0 )
+   z8 = (1.2345678901234567d0, 1.2345678901234567d0 )
    print *, 'Z8 defined with constants=',z8
 end program demo_aimag
 ```

--- a/source/learn/intrinsics/_pages/CMPLX.md
+++ b/source/learn/intrinsics/_pages/CMPLX.md
@@ -36,14 +36,11 @@ present. If **y** is present it is converted to the imaginary component. If
 The Fortran 90 language defines **cmplx**(3) as always returning a result
 that is type **complex(kind=KIND(0.0))**.
 
-This means \`**cmplx(d1,d2)**', where **\`d1'** and **\`d2'** are
+This means **cmplx(d1,d2)**, where **d1** and **d2** are
 _doubleprecision_, is treated as:
-fortran
-
-```
+```fortran
       cmplx(sngl(d1), sngl(d2))
 ```
-
 _doubleprecision complex_ numbers require specifying a precision.
 
 It was necessary for Fortran 90 to specify this behavior for
@@ -79,7 +76,7 @@ can be accessed independently with a component-like syntax in f2018:
 
 A complex-part-designator is
 
-``fortran
+```fortran
 designator % RE
 or
 designator % IM.
@@ -138,7 +135,7 @@ complex(kind=dp) :: z8
    ! NOTE:
    ! The following is intuitive and works without calling cmplx(3)
    ! but does not work for variables just constants
-   z8 = (1.2345678901234567d0, 1.2345678901234567d0 )
+   z8 = (1.2345678901234567d0 , 1.2345678901234567d0 )
    print *, 'Z8 defined with constants=',z8
 end program demo_aimag
 ```

--- a/source/learn/intrinsics/_pages/CO_REDUCE.md
+++ b/source/learn/intrinsics/_pages/CO_REDUCE.md
@@ -40,14 +40,14 @@ the occurred error.
   The function shall return a nonallocatable scalar of the same type
   and type parameters as **a**. The function shall be the same on all
   images and with regards to the arguments mathematically commutative
-  and associative. Note that OPERATION may not be an elemental
+  and associative. Note that OPERATION may not be an elemental unless
+  it is an intrinsic function.
 
-  - **function, unless it is an intrinsic function.**
-    result_image
+- **result_image**
 
-  - (optional) a scalar integer expression; if present, it shall
-    have the same the same value on all images and refer to an image
-    of the current team.
+  : (optional) a scalar integer expression; if present, it shall
+  have the same the same value on all images and refer to an image
+  of the current team.
 
 - **stat**
   : (optional) a scalar integer variable

--- a/source/learn/intrinsics/_pages/CPU_TIME.md
+++ b/source/learn/intrinsics/_pages/CPU_TIME.md
@@ -32,16 +32,15 @@ which time is an array.
 
 ### **Returns**
 
-- **TIME**
+- **time**
   : The type shall be _real_ with **intent(out)**. It is assigned a
   processor-dependent approximation to the processor time in seconds.
   If the processor cannot return a meaningful time, a
-  processor-dependent negative value
+  processor-dependent negative value is returned.
 
-  - **is returned.**
-    The start time is left imprecise because the purpose is to time
-    sections of code, as in the example. This might or might not
-    include system overhead time.
+  : The start time is left imprecise because the purpose is to time
+  sections of code, as in the example. This might or might not
+  include system overhead time.
 
 ### **Examples**
 

--- a/source/learn/intrinsics/_pages/DATE_AND_TIME.md
+++ b/source/learn/intrinsics/_pages/DATE_AND_TIME.md
@@ -37,22 +37,14 @@ Unavailable time and date _character_ parameters return blanks.
 - **values**
   : An _integer_ array of eight elements that contains:
 
-  - **values**(1)
-    : The year
-  - **values**(2)
-    : The month
-  - **values**(3)
-    : The day of the month
-  - **values**(4)
-    : Time difference with UTC in minutes
-  - **values**(5)
-    : The hour of the day
-  - **values**(6)
-    : The minutes of the hour
-  - **values**(7)
-    : The seconds of the minute
-  - **values**(8)
-    : The milliseconds of the second
+   - **values**(1) : The year
+   - **values**(2) : The month
+   - **values**(3) : The day of the month
+   - **values**(4) : Time difference with UTC in minutes
+   - **values**(5) : The hour of the day
+   - **values**(6) : The minutes of the hour
+   - **values**(7) : The seconds of the minute
+   - **values**(8) : The milliseconds of the second
 
 ### **Examples**
 

--- a/source/learn/intrinsics/_pages/EOSHIFT.md
+++ b/source/learn/intrinsics/_pages/EOSHIFT.md
@@ -20,16 +20,14 @@ all elements of **array** are shifted by **shift** places. If rank is greater
 than one, then all complete rank one sections of **array** along the given
 dimension are shifted. Elements shifted out one end of each rank one
 section are dropped. If **boundary** is present then the corresponding value
-of from **boundary** is copied back in the other end. If **boundary** is not
+from **boundary** is copied back in the other end. If **boundary** is not
 present then the following are copied in depending on the type of **array**.
 
-\*Array Type\* - \*Boundary Value\*
-
-- Numeric 0 of the type and kind of **array**
-
-- Logical .false.
-
-- **Character(len)** LEN blanks
+    Array Type     | Boundary Value
+    -----------------------------------------------------
+    Numeric        | 0 of the type and kind of **array**
+    Logical        | .false.
+    Character(len) |  LEN blanks
 
 ### **Arguments**
 
@@ -56,16 +54,18 @@ Sample program:
 ```fortran
 program demo_eoshift
 implicit none
-    integer, dimension(3,3) :: a
+integer, dimension(3,3) :: a
+integer :: i
+
     a = reshape( [ 1, 2, 3, 4, 5, 6, 7, 8, 9 ], [ 3, 3 ])
-    print '(3i3)', a(1,:)
-    print '(3i3)', a(2,:)
-    print '(3i3)', a(3,:)
-    a = eoshift(a, SHIFT=[1, 2, 1], BOUNDARY=-5, DIM=2)
+    print '(3i3)', (a(i,:),i=1,3)
+
     print *
-    print '(3i3)', a(1,:)
-    print '(3i3)', a(2,:)
-    print '(3i3)', a(3,:)
+
+    ! shift it
+    a = eoshift(a, SHIFT=[1, 2, 1], BOUNDARY=-5, DIM=2)
+    print '(3i3)', (a(i,:),i=1,3)
+
 end program demo_eoshift
 ```
 

--- a/source/learn/intrinsics/_pages/ERFC.md
+++ b/source/learn/intrinsics/_pages/ERFC.md
@@ -75,4 +75,4 @@ Fortran 2008 and later
 
 - [Wikipedia:error function](https://en.wikipedia.org/wiki/Error_function)
 
-###### fortran-lang intrinsic descriptions license: MIT) @urbanjost
+###### fortran-lang intrinsic descriptions (license: MIT) @urbanjost

--- a/source/learn/intrinsics/_pages/EXP.md
+++ b/source/learn/intrinsics/_pages/EXP.md
@@ -44,7 +44,7 @@ Sample program:
 ```fortran
 program demo_exp
 implicit none
-real :: x , re, im
+real :: x, re, im
 complex :: cx
 
    x = 1.0

--- a/source/learn/intrinsics/_pages/EXP.md
+++ b/source/learn/intrinsics/_pages/EXP.md
@@ -44,7 +44,7 @@ Sample program:
 ```fortran
 program demo_exp
 implicit none
-real :: x, re, im
+real :: x , re, im
 complex :: cx
 
    x = 1.0

--- a/source/learn/intrinsics/_pages/FINDLOC.md
+++ b/source/learn/intrinsics/_pages/FINDLOC.md
@@ -65,13 +65,13 @@ the result is an array of rank one and of size equal to the rank of
 **array**; otherwise, the result is of rank n - 1 and shape
 
 ```
-   [d1 , d2 , . . . , dDIM-1 , dDIM+1 , . . . , dn ]
+   [d1, d2, . . ., dDIM-1, dDIM+1, . . ., dn ]
 ```
 
 where
 
 ```
-   [d1 , d2 , . . . , dn ]
+   [d1, d2, . . ., dn ]
 ```
 
 is the shape of **array**.
@@ -82,7 +82,7 @@ is the shape of **array**.
   The result of **findloc (array, value)** is a rank-one array whose
   element values are the values of the subscripts of an element of
   **array** whose value matches **value**. If there is such a value, the
-  ith subscript returned lies in the range 1 to ei , where ei is the
+  ith subscript returned lies in the range 1 to ei, where ei is the
   extent of the ith dimension of **array**. If no elements match **value**
   or **array** has size zero, all elements of the result are zero.
 
@@ -91,7 +91,7 @@ is the shape of **array**.
   rank-one array whose element values are the values of the subscripts
   of an element of **array**, corresponding to a true element of **mask**,
   whose value matches **value**. If there is such a value, the ith
-  subscript returned lies in the range 1 to ei , where ei is the
+  subscript returned lies in the range 1 to ei, where ei is the
   extent of the ith dimension of **array**. If no elements match
   **value**, **array** has size zero, or every element of **mask** has the
   value false, all elements of the result are zero.
@@ -112,7 +112,7 @@ is a scalar whose value is equal to that of the first element of
 Otherwise, the value of element
 
 ```
-      (s1 , s2 , . . . , sDIM-1 , sDIM+1 , . . . , sn )
+      (s1, s2, . . ., sDIM-1, sDIM+1, . . ., sn )
 ```
 
 of the result is equal to
@@ -120,7 +120,7 @@ of the result is equal to
 ```
       findloc (array (s1, s2, ..., sdim-1, :, sdim+1, ..., sn ), &
       value, dim=1 [, mask = mask (s1, s2, ..., sdim-1, :,
-                      sdim+1 , ... , sn )]).
+                      sdim+1, ..., sn )]).
 ```
 
 ### **Examples**

--- a/source/learn/intrinsics/_pages/FINDLOC.md
+++ b/source/learn/intrinsics/_pages/FINDLOC.md
@@ -82,7 +82,7 @@ is the shape of **array**.
   The result of **findloc (array, value)** is a rank-one array whose
   element values are the values of the subscripts of an element of
   **array** whose value matches **value**. If there is such a value, the
-  ith subscript returned lies in the range 1 to ei, where ei is the
+  ith subscript returned lies in the range 1 to ei , where ei is the
   extent of the ith dimension of **array**. If no elements match **value**
   or **array** has size zero, all elements of the result are zero.
 
@@ -91,7 +91,7 @@ is the shape of **array**.
   rank-one array whose element values are the values of the subscripts
   of an element of **array**, corresponding to a true element of **mask**,
   whose value matches **value**. If there is such a value, the ith
-  subscript returned lies in the range 1 to ei, where ei is the
+  subscript returned lies in the range 1 to ei , where ei is the
   extent of the ith dimension of **array**. If no elements match
   **value**, **array** has size zero, or every element of **mask** has the
   value false, all elements of the result are zero.

--- a/source/learn/intrinsics/_pages/GET_COMMAND_ARGUMENT.md
+++ b/source/learn/intrinsics/_pages/GET_COMMAND_ARGUMENT.md
@@ -36,7 +36,7 @@ shells are ignored.
 ### **Returns**
 
 - **value**
-  :Shall be a scalar of type _character_ and of default kind. After
+  : Shall be a scalar of type _character_ and of default kind. After
   get_command_argument returns, the **value** argument holds the
   **number**-th command line argument. If **value** can not hold the argument,
   it is truncated to fit the length of **value**. If there are less than
@@ -44,11 +44,11 @@ shells are ignored.
   with blanks.
 
 - **length**
-  :(Optional) Shall be a scalar of type _integer_. The **length**
+  : (Optional) Shall be a scalar of type _integer_. The **length**
   argument contains the length of the **number**-th command line argument.
 
 - **status**
-  :(Optional) Shall be a scalar of type _integer_. If the argument
+  : (Optional) Shall be a scalar of type _integer_. If the argument
   retrieval fails, **status** is a positive number; if **value** contains a
   truncated command line argument, **status** is **-1**; and otherwise the
   **status** is zero.

--- a/source/learn/intrinsics/_pages/GET_ENVIRONMENT_VARIABLE.md
+++ b/source/learn/intrinsics/_pages/GET_ENVIRONMENT_VARIABLE.md
@@ -1,4 +1,4 @@
-## get_environment
+## get_environment_variable
 
 ### **Name**
 
@@ -29,7 +29,7 @@ being updated concurrently.
 - **name**
   : The name of the environment variable to query.
 
-  Shall be a scalar of type _character_ and of default kind.
+    Shall be a scalar of type _character_ and of default kind.
 
 ### **Returns**
 
@@ -37,9 +37,9 @@ being updated concurrently.
   : The value of the environment variable being queried.
 
   Shall be a scalar of type _character_ and of default kind.
-  The value of **name** is stored in **value**. If **value** is not large enough
-  to hold the data, it is truncated. If **name** is not set, **value** will be
-  filled with blanks.
+  The value of **name** is stored in **value**. If **value** is not
+  large enough to hold the data, it is truncated. If **name** is not
+  set, **value** will be filled with blanks.
 
 - **length**
   : Argument **length** contains the length needed for storing the
@@ -49,16 +49,16 @@ being updated concurrently.
 
 - **status**
   : **status** is **-1** if **value** is present but too short for the
-  environment variable; it is **1** if the environment variable does not
-  exist and **2** if the processor does not support environment variables;
-  in all other cases **status** is zero.
+  environment variable; it is **1** if the environment variable does
+  not exist and **2** if the processor does not support environment
+  variables; in all other cases **status** is zero.
 
   Shall be a scalar of type _integer_ and of default kind.
 
 - **trim_name**
-  : If **trim_name** is present with the value **.false.**, the trailing blanks in
-  **name** are significant; otherwise they are not part of the environment
-  variable name.
+  : If **trim_name** is present with the value **.false.**, the trailing
+  blanks in **name** are significant; otherwise they are not part of the
+  environment variable name.
 
   Shall be a scalar of type _logical_ and of default kind.
 

--- a/source/learn/intrinsics/_pages/HYPOT.md
+++ b/source/learn/intrinsics/_pages/HYPOT.md
@@ -17,7 +17,8 @@ where **x,y,value** shall all be of the same **kind**.
 
 ### **Description**
 
-**hypot(x,y)** is referred to as the Euclidean distance function. It is equal to $\sqrt{x^2+y^2}$ , without undue underflow or overflow.
+**hypot(x,y)** is referred to as the Euclidean distance function. It is
+equal to $\sqrt{x^2+y^2}$, without undue underflow or overflow.
 
 In mathematics, the _Euclidean distance_ between two points in Euclidean
 space is the length of a line segment between two points.
@@ -36,8 +37,8 @@ space is the length of a line segment between two points.
 
 The return value has the same type and kind type parameter as **x**.
 
-The result is the positive magnitude of the distance of the point **<x,y>** from the
-origin **<0.0,0.0>** .
+The result is the positive magnitude of the distance of the point
+**<x,y>** from the origin **<0.0,0.0>** .
 
 ### **Examples**
 

--- a/source/learn/intrinsics/_pages/HYPOT.md
+++ b/source/learn/intrinsics/_pages/HYPOT.md
@@ -17,7 +17,7 @@ where **x,y,value** shall all be of the same **kind**.
 
 ### **Description**
 
-**hypot(x,y)** is referred to as the Euclidean distance function. It is equal to $\sqrt{x^2+y^2}$, without undue underflow or overflow.
+**hypot(x,y)** is referred to as the Euclidean distance function. It is equal to $\sqrt{x^2+y^2}$ , without undue underflow or overflow.
 
 In mathematics, the _Euclidean distance_ between two points in Euclidean
 space is the length of a line segment between two points.

--- a/source/learn/intrinsics/_pages/IOR.md
+++ b/source/learn/intrinsics/_pages/IOR.md
@@ -39,7 +39,7 @@ implicit none
 integer :: i, j, k
    i=53       ! i=00110101 binary (lowest order byte)
    j=45       ! j=00101101 binary (lowest order byte)
-   k=ior(i,j) ! k=00111101 binary (lowest order byte) , k=61 decimal
+   k=ior(i,j) ! k=00111101 binary (lowest order byte), k=61 decimal
    write(*,'(i8,1x,b8.8)')i,i,j,j,k,k
 end program demo_ior
 ```

--- a/source/learn/intrinsics/_pages/IOR.md
+++ b/source/learn/intrinsics/_pages/IOR.md
@@ -39,7 +39,7 @@ implicit none
 integer :: i, j, k
    i=53       ! i=00110101 binary (lowest order byte)
    j=45       ! j=00101101 binary (lowest order byte)
-   k=ior(i,j) ! k=00111101 binary (lowest order byte), k=61 decimal
+   k=ior(i,j) ! k=00111101 binary (lowest order byte) , k=61 decimal
    write(*,'(i8,1x,b8.8)')i,i,j,j,k,k
 end program demo_ior
 ```

--- a/source/learn/intrinsics/_pages/MAXLOC.md
+++ b/source/learn/intrinsics/_pages/MAXLOC.md
@@ -13,15 +13,15 @@ result = maxloc(array, dim, mask) result = maxloc(array, mask)
 ### **Description**
 
 Determines the location of the element in the array with the maximum
-value, or, if the **dim** argument is supplied, determines the locations of
-the maximum element along each row of the array in the **dim** direction. If
-**mask** is present, only the elements for which **mask** is **.true.** are
-considered. If more than one element in the array has the maximum value,
-the location returned is that of the first such element in array element
-order. If the array has zero size, or all of the elements of **mask** are
-.false., then the result is an array of zeroes. Similarly, if **dim** is
-supplied and all of the elements of **mask** along a given row are zero, the
-result value for that row is zero.
+value, or, if the **dim** argument is supplied, determines the locations
+of the maximum element along each row of the array in the **dim**
+direction. If **mask** is present, only the elements for which **mask**
+is **.true.** are considered. If more than one element in the array has
+the maximum value, the location returned is that of the first such element
+in array element order. If the array has zero size, or all of the elements
+of **mask** are .false., then the result is an array of zeroes. Similarly,
+if **dim** is supplied and all of the elements of **mask** along a given
+row are zero, the result value for that row is zero.
 
 ### **Arguments**
 
@@ -38,12 +38,12 @@ result value for that row is zero.
 
 ### **Returns**
 
-If **dim** is absent, the result is a rank-one array with a length equal to
-the rank of **array**. If **dim** is present, the result is an array with a rank
-one less than the rank of **array**, and a size corresponding to the size of
-**array** with the **dim** dimension removed. If **dim** is present and **array** has a
-rank of one, the result is a scalar. In all cases, the result is of
-default _integer_ type.
+If **dim** is absent, the result is a rank-one array with a length equal
+to the rank of **array**. If **dim** is present, the result is an array
+with a rank one less than the rank of **array**, and a size corresponding
+to the size of **array** with the **dim** dimension removed. If **dim**
+is present and **array** has a rank of one, the result is a scalar. In
+all cases, the result is of default _integer_ type.
 
 The value returned is reference to the offset from the beginning of the
 array, not necessarily the subscript value if the array subscripts do

--- a/source/learn/intrinsics/_pages/MERGE_BITS.md
+++ b/source/learn/intrinsics/_pages/MERGE_BITS.md
@@ -10,7 +10,7 @@
 result = merge_bits(i, j, mask)
 
     elemental function merge_bits(i,j,mask) result(r)
-    integer(kind=KIND) ,intent(in) :: i, j, mask
+    integer(kind=KIND), intent(in) :: i, j, mask
     integer(kind=KIND) :: r
 ```
 
@@ -89,7 +89,7 @@ character(len=*),parameter :: fmt='(*(g0, 1X))'
    ! using BOZ values
    print fmt, &
    & merge_bits(32767_int16,    o'12345',         32767_int16), &
-   & merge_bits(o'12345'   , 32767_int16, b'0000000000010101'), &
+   & merge_bits(o'12345', 32767_int16, b'0000000000010101'), &
    & merge_bits(32767_int16,    o'12345',             z'1234')
 
    ! a do-it-yourself equivalent for comparison and validation
@@ -119,4 +119,4 @@ Results:
 
 Fortran 2008 and later
 
-###### fortran-lang intrinsic descriptions (license MIT) @urbanjost
+###### fortran-lang intrinsic descriptions (license: MIT) @urbanjost

--- a/source/learn/intrinsics/_pages/MERGE_BITS.md
+++ b/source/learn/intrinsics/_pages/MERGE_BITS.md
@@ -10,7 +10,7 @@
 result = merge_bits(i, j, mask)
 
     elemental function merge_bits(i,j,mask) result(r)
-    integer(kind=KIND), intent(in) :: i, j, mask
+    integer(kind=KIND) ,intent(in) :: i, j, mask
     integer(kind=KIND) :: r
 ```
 

--- a/source/learn/intrinsics/_pages/MIN.md
+++ b/source/learn/intrinsics/_pages/MIN.md
@@ -19,8 +19,8 @@ Returns the argument with the smallest (most negative) value.
 - **a1**
   : The type shall be _integer_ or _real_.
 
-- **a2, a3, \`\`\`**
-  : An expression of the same type and kind as **A1**.
+- **a2, a3, ...**
+  : An expression of the same type and kind as **a1**.
 
 ### **Returns**
 

--- a/source/learn/intrinsics/_pages/MOVE_ALLOC.md
+++ b/source/learn/intrinsics/_pages/MOVE_ALLOC.md
@@ -12,8 +12,8 @@ call move_alloc(src, dest)
 
 ### **Description**
 
-**move_alloc(src, dest)** moves the allocation from SRC to DEST. SRC
-will become deallocated in the process.
+**move_alloc(src, dest)** moves the allocation from **src*( to
+**dest*. **src** will become deallocated in the process.
 
 ### **Arguments**
 
@@ -22,7 +22,7 @@ will become deallocated in the process.
 
 - **dest**
   : allocatable, **intent(out)**, shall be of the same type, kind and
-  rank as SRC.
+  rank as **src*.
 
 ### **Examples**
 

--- a/source/learn/intrinsics/_pages/MVBITS.md
+++ b/source/learn/intrinsics/_pages/MVBITS.md
@@ -145,4 +145,4 @@ Fortran 95 and later
 [**ior**(3)](IOR),
 [**ieor**(3)](IEOR)
 
-###### fortran-lang intrinsic descriptions (license MIT) @urbanjost
+###### fortran-lang intrinsic descriptions (license: MIT) @urbanjost

--- a/source/learn/intrinsics/_pages/NORM2.md
+++ b/source/learn/intrinsics/_pages/NORM2.md
@@ -50,7 +50,7 @@ implicit none
 
 real :: x(3,3) = reshape([ &
    1, 2, 3, &
-   4, 5 ,6, &
+   4, 5, 6, &
    7, 8, 9  &
 ],shape(x),order=[2,1])
 

--- a/source/learn/intrinsics/_pages/NORM2.md
+++ b/source/learn/intrinsics/_pages/NORM2.md
@@ -47,11 +47,10 @@ Sample program:
 ```fortran
 program demo_norm2
 implicit none
-integer :: i
 
 real :: x(3,3) = reshape([ &
    1, 2, 3, &
-   4, 5, 6, &
+   4, 5 ,6, &
    7, 8, 9  &
 ],shape(x),order=[2,1])
 

--- a/source/learn/intrinsics/_pages/REDUCE.md
+++ b/source/learn/intrinsics/_pages/REDUCE.md
@@ -1,0 +1,189 @@
+## reduce
+
+### **Name**
+
+**reduce**(3) - \[TRANSFORMATIONAL\] general reduction of an array
+
+### **Syntax**
+
+There are two forms to this function:
+```fortran
+
+   reduce(array, operation, mask, identity, ordered)
+   reduce(array, operation, dim, mask, identity, ordered)
+```
+
+```fortran
+      type(TYPE),intent(in)          :: array
+      pure function                  :: operation
+      integer,intent(in),optional    :: dim
+      logical,optional               :: mask
+      type(TYPE),intent(in),optional :: identity
+      logical,intent(in),optional    :: ordered
+```
+   where TYPE may be of any type. TYPE must be the same for **array**
+   and **identity**.
+
+### **description**
+
+   Reduce a list of conditionally selected values from an array to a
+   single value by iteratively applying a binary function.
+
+   Common in functional programming, a **reduce** function applies a
+   binary operator (a pure function with two arguments) to all elements
+   cumulatively.
+
+   **reduce** is a "higher-order" function; ie. it is a function that
+   receives other functions as arguments.
+
+   The **reduce** function receives a binary operator (a function with
+   two arguments, just like the basic arithmetic operators). It is first
+   applied to two unused values in the list to generate an accumulator
+   value which is subsequently used as the first argument to the function
+   as the function is recursively applied to all the remaining selected
+   values in the input array.
+
+### **options**
+
+- **array**
+  : An array of any type and allowed rank to select values from.
+
+- **operation**
+  : shall be a pure function with exactly two arguments;
+  each argument shall be a scalar, nonallocatable,
+  nonpointer, nonpolymorphic, nonoptional dummy data object
+  with the same type and type parameters as **array**. If
+  one argument has the ASYNCHRONOUS, TARGET, or VALUE
+  attribute, the other shall have that attribute. Its result
+  shall be a nonpolymorphic scalar and have the same type
+  and type parameters as **array**. **operation** should
+  implement a mathematically associative operation. It
+  need not be commutative.
+
+  NOTE
+
+  If **operation** is not computationally associative, REDUCE
+  without ORDERED=.TRUE. with the same argument values
+  might not always produce the same result, as the processor
+  can apply the associative law to the evaluation.
+
+  Many operations that mathematically are associative are
+  not when applied to floating-point numbers. The order
+  you sum values in may affect the result, for example.
+
+- **dim**
+  : An integer scalar with a value in the range
+  1<= **dim** <= n, where n is the rank of **array**.
+
+- **mask**
+  : (optional) shall be of type logical and shall be
+  conformable with **array**.
+
+  When present only those elements of **array** are passed
+  to **operation** for which the corresponding elements
+  of **mask** are true, as if **array* was filtered with
+  **pack(3)**.
+
+- **identity**
+  : shall be scalar with the same type and type parameters as **array**.
+  If the initial sequence is empty, the result has the value **identify**
+  if **identify** is present, and otherwise, error termination is
+  initiated.
+
+- **ordered**
+  : shall be a logical scalar. If **ordered** is present with the value
+  _.true._, the calls to the **operator** function begins with the first
+  two elements of **array** and the process continues in row-column
+  order until the sequence has only one element which is the value of the
+  reduction. Otherwise, the compiler is free to assume that the operation
+  is commutative and may evaluate the reduction in the most optimal way.
+
+### **result**
+
+The result is of the same type and type parameters as **array**. It is
+scalar if **dim** does not appear.
+
+If **dim** is present, it indicates the one dimension along which to
+perform the reduction, and the resultant array has a rank reduced by
+one relative to the input array.
+
+### **examples**
+
+   The following examples all use the function MY_MULT, which returns
+   the product of its two real arguments.
+```fortran
+   program demo_reduce
+   implicit none
+   character(len=*),parameter :: f='("[",*(g0,",",1x),"]")'
+   integer,allocatable :: arr(:), b(:,:)
+
+   ! Basic usage:
+      ! the product of the elements of an array
+      arr=[1, 2, 3, 4 ]
+      write(*,*) arr
+      write(*,*) 'product=', reduce(arr, my_mult)
+      write(*,*) 'sum=', reduce(arr, my_sum)
+
+   ! Examples of masking:
+      ! the product of only the positive elements of an array
+      arr=[1, -1, 2, -2, 3, -3 ]
+      write(*,*)'positive value product=',reduce(arr, my_mult, mask=arr>0)
+      !write(*,*)'positive value sum=',reduce(pack(arr,mask=arr>0), my_mult )
+   ! sum values ignoring negative values
+      write(*,*)'sum positive values=',reduce(arr, my_sum, mask=arr>0)
+      !write(*,*)'sum positive values=',reduce(pack(arr,mask=arr>0), my_sum )
+
+   ! a single-valued array returns the single value as the
+   ! calls to the operator stop when only one element remains
+      arr=[ 1234 ]
+      write(*,*)'single value sum',reduce(arr, my_sum )
+      write(*,*)'single value product',reduce(arr, my_mult )
+
+   ! Example of operations along a dimension:
+   !  If B is the array   1 3 5
+   !                      2 4 6
+      b=reshape([1,2,3,4,5,6],[2,3])
+      write(*,f) REDUCE(B, MY_MULT),'should be [720]'
+      write(*,f) REDUCE(B, MY_MULT, DIM=1),'should be [2,12,30]'
+      write(*,f) REDUCE(B, MY_MULT, DIM=2),'should be [15, 48]'
+
+   contains
+
+   pure function my_mult(a,b) result(c)
+   integer,intent(in) :: a, b
+   integer            :: c
+      c=a*b
+   end function my_mult
+
+   pure function my_sum(a,b) result(c)
+   integer,intent(in) :: a, b
+   integer            :: c
+      c=a+b
+   end function my_sum
+
+   end program demo_reduce
+```
+  Results:
+```text
+     >  1 2 3 4
+     >  product= 24
+     >  sum=     10
+     >  positive value sum= 6
+     >  sum positive values= 6
+     >  single value sum     1234
+     >  single value product 1234
+     > [720, should be [720],
+     > [2, 12, 30, should be [2,12,30],
+     > [15, 48, should be [15, 48],
+````
+
+### **See Also**
+- [co_reduce(3)](CO_REDUCE)
+- [associative:wipipedia](https://en.wikipedia.org/wiki/Associative_property)
+
+
+### **Standard**
+
+   Fortran 2018
+
+###### fortran-lang intrinsic descriptions (license: MIT) @urbanjost

--- a/source/learn/intrinsics/_pages/REPEAT.md
+++ b/source/learn/intrinsics/_pages/REPEAT.md
@@ -39,7 +39,7 @@ Sample program:
 ```fortran
 program demo_repeat
 implicit none
-integer :: i, j
+integer :: i
     write(*,'(a)') repeat("^v", 36)         ! line break
     write(*,'(a)') repeat("_", 72)          ! line break
     write(*,'(a)') repeat("1234567890", 7)  ! number line

--- a/source/learn/intrinsics/_pages/SELECTED_REAL_KIND.md
+++ b/source/learn/intrinsics/_pages/SELECTED_REAL_KIND.md
@@ -41,19 +41,24 @@ than one real data type meet the criteria, the kind of the data type
 with the smallest decimal precision is returned. If no real data type
 matches the criteria, the result is
 
-- **-1** if the processor does not support a real data type with a
-  precision greater than or equal to **p**, but the **r** and **radix**
-  requirements can be fulfilled
+  - **-1** 
+  : if the processor does not support a real data type with a
+    precision greater than or equal to **p**, but the **r** and **radix**
+    requirements can be fulfilled
 
-  - **-2** if the processor does not support a real type with an
+  - **-2** 
+  : if the processor does not support a real type with an
     exponent range greater than or equal to **r**, but **p** and **radix** are
     fulfillable
 
-  - **-3** if **radix** but not **p** and **r** requirements are fulfillable
+  - **-3** 
+  : if **radix** but not **p** and **r** requirements are fulfillable
 
-  - **-4** if **radix** and either **p** or **r** requirements are fulfillable
+  - **-4** 
+  : if **radix** and either **p** or **r** requirements are fulfillable
 
-  - **-5** if there is no real type with the given **radix**
+  - **-5** 
+  : if there is no real type with the given **radix**
 
 ### **Examples**
 

--- a/source/learn/intrinsics/_pages/SIGN.md
+++ b/source/learn/intrinsics/_pages/SIGN.md
@@ -28,14 +28,15 @@ __sign()__ may be used to distinguish between __real__ values 0.0 and
 −0.0. SIGN (1.0, -0.0) will return −1.0 when a negative zero is
 distinguishable.
 
-
 ### **Arguments**
 
   - **a**
-    : Shall be of type _integer_ or _real_
+    : The value whos magnitude will be returned. Shall be of type
+    _integer_ or _real_
 
   - **b**
-    : Shall be of the same type and kind as **a**
+    : The value whose sign will be returned. Shall be of the same type
+    and kind as **a**
 
 ### **Returns**
 
@@ -51,7 +52,6 @@ __b__. That is,
 ### **Examples**
 
 Sample program:
-
 ```fortran
 program demo_sign
 implicit none
@@ -65,7 +65,6 @@ implicit none
    &  sign( 1.0, -0.0 ) .ne. sign( 1.0, 0.0 )
 end program demo_sign
 ````
-
 Results:
 
 ```text
@@ -75,7 +74,6 @@ Results:
       12.00000       12.00000      -12.00000
     can I distinguish 0 from -0?  F
 ```
-
 ### **Standard**
 
 FORTRAN 77 and later

--- a/source/learn/intrinsics/_pages/SPREAD.md
+++ b/source/learn/intrinsics/_pages/SPREAD.md
@@ -21,8 +21,8 @@ result = spread(source, dim, ncopies)
 Replicates a **source** array **ncopies** times along a specified
 dimension **dim**.
 
-If SOURCE is scalar, the shape of the result is (MAX (NCOPIES, 0)).
-and each element of the result has a value equal to SOURCE.
+If **source** is scalar, the shape of the result is (MAX (NCOPIES, 0)).
+and each element of the result has a value equal to **source**.
 
 ### **Arguments**
 

--- a/source/learn/intrinsics/_pages/SQRT.md
+++ b/source/learn/intrinsics/_pages/SQRT.md
@@ -14,7 +14,7 @@ result = sqrt(x)
    TYPE(kind=KIND) :: value
 ```
 
-Where TYPE may be _real_ or _complex_ and **KIND** may be any
+Where **TYPE** may be _real_ or _complex_ and **KIND** may be any
 kind valid for the declared type.
 
 ### **Description**
@@ -34,7 +34,7 @@ is called the principal square root.
 The principal square root of 9 is 3, for example, even though (-3)\*(-3)
 is also 9.
 
-A _real_, _radicand_ must be positive.
+A _real_ radicand must be positive.
 
 Square roots of negative numbers are a special case of complex numbers,
 where the components of the _radicand_ need not be positive in order to
@@ -43,7 +43,7 @@ have a valid square root.
 ### **Arguments**
 
 - **x**
-  : If **x** is real its value must be greater than or equal to zero.
+  : If **x** is _real_ its value must be greater than or equal to zero.
   The type shall be _real_ or _complex_.
 
 ### **Returns**

--- a/source/learn/intrinsics/_pages/SUM.md
+++ b/source/learn/intrinsics/_pages/SUM.md
@@ -45,7 +45,7 @@ Sample program:
 ```fortran
 program simple_sum
 implicit none
-integer :: x(5) = [ 1, 2, 3, 4 ,5 ]
+integer :: x(5) = [ 1, 2, 3, 4, 5 ]
    print *, sum(x)                        ! all elements, sum = 15
    print *, sum(x, mask=mod(x, 2)==1)     ! odd elements, sum = 9
 end program simple_sum
@@ -65,7 +65,7 @@ data b/ndh*-1.0, nduh*2.0/
    csum= sum(c(1:nd))
    cpsum= sum (c(1:nd), mask=c.gt.0)
    cbpsum= sum(c(1:nd), mask=b.gt.0.0)
-   print *, 'Sum of all elements in c = ' , csum
+   print *, 'Sum of all elements in c = ', csum
    print *, 'Sum of Positive elements in c = ', cpsum
    print *, 'Sum of elements in c when corresponding elements in b>0', &
    & ' =', cbpsum

--- a/source/learn/intrinsics/_pages/SUM.md
+++ b/source/learn/intrinsics/_pages/SUM.md
@@ -45,7 +45,7 @@ Sample program:
 ```fortran
 program simple_sum
 implicit none
-integer :: x(5) = [ 1, 2, 3, 4, 5 ]
+integer :: x(5) = [ 1, 2, 3, 4 ,5 ]
    print *, sum(x)                        ! all elements, sum = 15
    print *, sum(x, mask=mod(x, 2)==1)     ! odd elements, sum = 9
 end program simple_sum
@@ -65,7 +65,7 @@ data b/ndh*-1.0, nduh*2.0/
    csum= sum(c(1:nd))
    cpsum= sum (c(1:nd), mask=c.gt.0)
    cbpsum= sum(c(1:nd), mask=b.gt.0.0)
-   print *, 'Sum of all elements in c = ', csum
+   print *, 'Sum of all elements in c = ' , csum
    print *, 'Sum of Positive elements in c = ', cpsum
    print *, 'Sum of elements in c when corresponding elements in b>0', &
    & ' =', cbpsum

--- a/source/learn/intrinsics/_pages/THIS_IMAGE.md
+++ b/source/learn/intrinsics/_pages/THIS_IMAGE.md
@@ -7,10 +7,16 @@
 ### **Syntax**
 
 ```fortran
-   result = this_image() 
-   !or
-   result = this_image(distance) 
-   result = this_image(coarray, dim)
+result = this_image() 
+```
+or
+```
+```fortran
+result = this_image(distance) 
+```
+or
+```fortran
+result = this_image(coarray, dim)
 ```
 
 ### **Description**

--- a/source/learn/intrinsics/_pages/TINY.md
+++ b/source/learn/intrinsics/_pages/TINY.md
@@ -37,8 +37,8 @@ Sample program:
 ```fortran
 program demo_tiny
 implicit none
-   print *, 'default real is from',tiny(0.0) ,'to',huge(0.0)
-   print *, 'doubleprecision is from ',tiny(0.0d0),'to',huge(0.0d0)
+   print *, 'default real is from', tiny(0.0), 'to',huge(0.0)
+   print *, 'doubleprecision is from ', tiny(0.0d0), 'to',huge(0.0d0)
 end program demo_tiny
 ```
 

--- a/source/learn/intrinsics/_pages/TINY.md
+++ b/source/learn/intrinsics/_pages/TINY.md
@@ -37,7 +37,7 @@ Sample program:
 ```fortran
 program demo_tiny
 implicit none
-   print *, 'default real is from',tiny(0.0),'to',huge(0.0)
+   print *, 'default real is from',tiny(0.0) ,'to',huge(0.0)
    print *, 'doubleprecision is from ',tiny(0.0d0),'to',huge(0.0d0)
 end program demo_tiny
 ```

--- a/source/learn/intrinsics/_pages/TRANSFER.md
+++ b/source/learn/intrinsics/_pages/TRANSFER.md
@@ -16,7 +16,7 @@ Interprets the bitwise representation of **source** in memory as if it
 is the representation of a variable or array of the same type and type
 parameters as **mold**.
 
-This is approximately equivalent to the C concept of \*casting\* one
+This is approximately equivalent to the C concept of "casting" one
 type to another.
 
 ### **Arguments**

--- a/source/learn/intrinsics/_pages/UNPACK.md
+++ b/source/learn/intrinsics/_pages/UNPACK.md
@@ -2,17 +2,27 @@
 
 ### **Name**
 
-**unpack**(3) - \[ARRAY CONSTRUCTION\] Store the elements of a vector in an array of higher rank
+**unpack**(3) - \[ARRAY CONSTRUCTION\] scatter the elements of a vector
+into an array using a mask
 
 ### **Syntax**
 
 ```fortran
 result = unpack(vector, mask, field)
-```
 
+ type(TYPE(kind=KIND)),intent(in) :: vector(:)
+ logical,intent(in)               :: mask(..)
+ type(TYPE(kind=KIND)),intent(in) :: field(..)
+ type(TYPE(kind=KIND))            :: result(..)
+```
 ### **Description**
 
-Store the elements of **vector** in an array of higher rank.
+Scatter the elements of **vector** into a copy of an array **field**
+of any rank using _.true._ values from **mask** in array element order
+to specify placement of the **vector** values.
+
+So a copy of **field** is generated with select elements replaced with
+values from **vector**.
 
 ### **Arguments**
 
@@ -21,17 +31,54 @@ Store the elements of **vector** in an array of higher rank.
   as many elements as **mask** has **.true.** values.
 
 - **mask**
-  : Shall be an array of type _logical_.
+  : Shall be an array of type _logical_. 
 
 - **field**
-  : Shall be of the same type as **vector** and have the same shape as **mask**.
+  : Shall be of the same type and type parameters as **vector** and
+  shall be conformable with **mask**.
+
 
 ### **Returns**
 
-The resulting array corresponds to **field** with **.true.** elements of **mask**
-replaced by values from **vector** in array element order.
+The result is an array of the same type and type parameters as **vector**
+and the same shape as **mask**.
+
+The element of the result that corresponds to the ith true element
+of MASK, in array element order, has the value VECTOR (i) for i =
+1, 2, . . ., t, where t is the number of true values in MASK. Each
+other element has a value equal to FIELD if FIELD is scalar or to the
+corresponding element of FIELD if it is an array.
+
+The resulting array corresponds to **field** with **.true.** elements
+of **mask** replaced by values from **vector** in array element order.
+
+
 
 ### **Examples**
+Particular values may be "scattered" to particular positions in an array by using
+```text
+                       1 0 0        
+    If M is the array  0 1 0 
+                       0 0 1  
+
+    V is the array [1, 2, 3],
+		               . T .
+    and Q is the logical mask  T . .
+  	                       . . T
+    where "T" represents true and "." represents false, then the result of 
+
+    UNPACK (V, MASK = Q, FIELD = M) has the value
+                                       
+      1 2 0 
+      1 1 0  
+      0 0 3 
+
+    and the result of UNPACK (V, MASK = Q, FIELD = 0) has the value
+
+      0 2 0
+      1 0 0 
+      0 0 3
+```
 
 Sample program:
 

--- a/source/learn/intrinsics/index.md
+++ b/source/learn/intrinsics/index.md
@@ -24,15 +24,14 @@ system/index
 transform/index
 type/index
 GNU Free Documentation License <https://www.gnu.org/licenses/old-licenses/fdl-1.2.en.html>
-```
 
 ::::
 
 ## Overview
 
-The standard documents and most vendor-supplied descriptions of
-the intrinsics are often very brief and concise to the point of the
-functionality of the intrinsics being obscure, particularly to someone
+The standard documents and most vendor-supplied descriptions of the
+intrinsics are often very brief and concise to the point where the
+functionality of the intrinsics becomes obscure, particularly to someone
 unfamiliar with the procedure.
 
 By describing the procedures here
@@ -43,7 +42,7 @@ By describing the procedures here
   (including additional documents at fortran-lang.org and related
   discussions in Fortran Discourse)
 
-these documents strive to be a valuable asset for Fortran programmers.
+these documents strive to clarify the intrinsics for Fortran programmers.
 
 This is a community-driven resource and everyone is encouraged to contribute
 to the documents. For contribution guidelines see {ref}`minibooks`
@@ -52,65 +51,24 @@ and the following Copyright guidelines.
 ## See Also
 
 - The [Fortran stdlib](https://stdlib.fortran-lang.org/) project
-- [fpm(1)](https://fortran-lang.org/packages/fpm) packages, many of which are general-purpose libraries/modules
 
-Experimental
+- [fpm(1)](https://fortran-lang.org/packages/fpm) packages, many of
+  which are general-purpose libraries/modules
 
-- [review by procedure ](http://www.urbanjost.altervista.org/SUPPLEMENTS/slidy_byprocedure.html)
-
-- [review by header ](http://www.urbanjost.altervista.org/SUPPLEMENTS/slidy_byheader.html)
-
-- [fman(1)](http://www.urbanjost.altervista.org/SUPPLEMENTS/fman.f90) A self-contained Fortran program that
-  lets you view the non-graphical plain ASCII portions of the
-  documentation from a terminal interface. Compile the program and
-  enter "./fman --help" for directions.
-
-- [man pages](http://www.urbanjost.altervista.org/SUPPLEMENTS/fortran.tgz) A gzipped tar(1) file containing
-  early versions of man-pages derived from the markdown documents.
-
-  Typical installation on a Linux platform as an administrator ( but it varies) :
-
-```bash
-# as the administrator
-cd /usr/share
-tar xvfz /tmp/fortran.tgz
-cd man
-mandb -c
-```
-
-then anyone on that plaform can enter commands like
-
-```bash
-man sinh.3fortran     # specifically show Fortran sinh(3) documentation
-man -k . -s 3fortran  # list all fortran pages
-man -s 3fortran --regex '.*' |col -b # show all Fortran intrinsics
-```
-
-See man(1) (ie. enter "man man") for more information.
-
-If you can only install the pages on your own ID, try
-
-```bash
-# as a user, placing the files in ~/man:
-cd
-tar xvfz /tmp/fortran.tgz
-cd man
-mandb -c
-export MANPATH="$MANPATH:$HOME/man"
-export MANWIDTH=80
-```
-
-Still debating whether having to keep the document limited to ANSI
-characters is worth-while so these formats can be generated, and
-still having issues converting the markdown to the proper formats.
+- [M_intrinsics](https://github.com/urbanjost/M_intrinsics) a related project
+  to leverage the descriptions here to generate man-pages and an OS-agnostic CLI
+  (Command Line Interface) program. This includes a tar(1) and zip(1)
+  file of man-pages and a self-contained Fortran program that lets you
+  view the non-graphical plain ASCII portions of the documentation from
+  a terminal interface.
 
 ## Text Content Copyrights
 
-Many of the documents presented here are modified versions of man-pages from the
-[Fortran Wiki](https://fortranwiki.org)
-and as such are available under the terms of the GNU
-Free Documentation License [**GFDL**](GNU_Free_Documentation_License.md)
-with no invariant sections, front-cover texts, or back-cover texts.
+Many of the documents presented here are modified versions of
+man-pages from the [Fortran Wiki](https://fortranwiki.org) and as such
+are available under the terms of the GNU Free Documentation License
+[**GFDL**](GNU_Free_Documentation_License.md) with no invariant sections,
+front-cover texts, or back-cover texts.
 
 If you contribute to this site by modifying the files marked as GFDL,
 you thereby agree to license the contributed material to the public

--- a/source/learn/intrinsics/transform/index.md
+++ b/source/learn/intrinsics/transform/index.md
@@ -23,3 +23,7 @@
 ```{include} ../_pages/NULL.md
 
 ```
+
+```{include} ../_pages/REDUCE.md
+
+```


### PR DESCRIPTION
Added REDUCE description, corrected additional errata and made some style changes, some of which are needed to be able to built the man-pages.

Added
 - /REDUCE.md

Altered
 - /ABS.md
 - /ADJUSTR.md
 - /ALL.md
 - /BGT.md
 - /BIT_SIZE.md
 - /BLE.md
 - /CMPLX.md
 - /CO_REDUCE.md
 - /CPU_TIME.md
 - /DATE_AND_TIME.md
 - /EOSHIFT.md
 - /EXP.md
 - /FINDLOC.md
 - /GET_COMMAND_ARGUMENT.md
 - /GET_ENVIRONMENT_VARIABLE.md
 - /HYPOT.md
 - /IOR.md
 - /MAXLOC.md
 - /MERGE_BITS.md
 - /MIN.md
 - /MOVE_ALLOC.md
 - /NORM2.md
 - /REPEAT.md
 - /SELECTED_REAL_KIND.md
 - /SPREAD.md
 - /SQRT.md
 - /SUM.md
 - /THIS_IMAGE.md
 - /TINY.md
 - /TRANSFER.md

 - index.md
 - transform/index.md