### PR TITLE
Link to online compiler playground #44

### DIFF
--- a/source/index.md
+++ b/source/index.md
@@ -150,7 +150,7 @@ Or just write Fortran software for your research, business, or schoolwork. You c
 :::{toctree}
 :hidden:
 
-Play <https://play.fortran-lang.org/>
+Fortran Playground <https://play.fortran-lang.org/>
 learn
 compilers
 community

--- a/source/index.md
+++ b/source/index.md
@@ -150,6 +150,7 @@ Or just write Fortran software for your research, business, or schoolwork. You c
 :::{toctree}
 :hidden:
 
+Play <https://play.fortran-lang.org/>
 learn
 compilers
 community

--- a/source/learn.md
+++ b/source/learn.md
@@ -66,6 +66,30 @@ Ask a question in the Fortran-lang discourse - a forum for friendly discussion o
 :::
 ::::
 :::::
+
+:::::{grid-item}
+
+::::{grid} 1 1 1 1
+:gutter: 1
+
+:::{grid-item-card} {octicon}`play;1em;sd-text-info` Play with Fortran
+:shadow: none
+
+Get a taste of Fortran in an interactive playground in the browser.
+
+```{card}
+:link-type: url
+:link: https://play.fortran-lang.org/
+:class-card: sd-btn
+:class-body: sd-p-1 sd-text-center sd-font-weight-bold sd-text-info sd-btn-primary sd-text-light sd-btn
+:shadow: none
+
+{octicon}``play;1em;sd-text-info`` Fortran Playground
+```
+
+:::
+::::
+:::::
 ::::::
 
 :::{div} sd-fs-3 sd-font-weight-bold sd-text-primary


### PR DESCRIPTION
The Fortran-lang playground (https://github.com/fortran-lang/playground) should be linked from the webpage to make it easier to discover. Please refer #44   for more details. 

Possible options are:

- in the top navigation bar
- in the compiler section next to the supported compilers

CC @awvwgk @ashirrwad, @everythingfunctional @milancurcic 