### PR TITLE
change footer from header level six to italics text

### DIFF
--- a/source/learn/intrinsics/_pages/ABS.md
+++ b/source/learn/intrinsics/_pages/ABS.md
@@ -119,4 +119,4 @@ end program demo_abs
 
    FORTRAN 77 and later
 
- _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_
+ _fortran-lang intrinsic descriptions (license: MIT) \@urbanjost_

--- a/source/learn/intrinsics/_pages/ABS.md
+++ b/source/learn/intrinsics/_pages/ABS.md
@@ -80,7 +80,7 @@ integer,parameter :: dp=kind(0.0d0)
   ! elemental
     write(*, *) 'abs is elemental: ', abs([20,  0,  -1,  -3,  100])
 
-  ! complex input produces real output  
+  ! complex input produces real output
     write(*, *)  cmplx(30.0,40.0)
 
   ! the returned value for complex input can be thought of as the
@@ -112,11 +112,11 @@ end program demo_abs
     abs range test :   1.1754944E-38  1.1754944E-38
     abs is elemental: 20 0 1 3 100
     (30.00000,40.00000)
-    distance of <XX,YY> from zero is   50.0000000000000     
+    distance of <XX,YY> from zero is   50.0000000000000
 ```
 
 ### **Standard**
 
    FORTRAN 77 and later
 
-###### fortran-lang intrinsic descriptions (license: MIT) @urbanjost
+ _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_

--- a/source/learn/intrinsics/_pages/ACHAR.md
+++ b/source/learn/intrinsics/_pages/ACHAR.md
@@ -170,4 +170,4 @@ FORTRAN 77 and later, with KIND argument Fortran 2003 and later
 - [ANSI escape sequences](https://en.wikipedia.org/wiki/ANSI_escape_code)
 - [M_attr module](https://github.com/urbanjost/M_attr) for controlling ANSI-compatible terminals
 
- _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_
+ _fortran-lang intrinsic descriptions (license: MIT) \@urbanjost_

--- a/source/learn/intrinsics/_pages/ACHAR.md
+++ b/source/learn/intrinsics/_pages/ACHAR.md
@@ -170,4 +170,4 @@ FORTRAN 77 and later, with KIND argument Fortran 2003 and later
 - [ANSI escape sequences](https://en.wikipedia.org/wiki/ANSI_escape_code)
 - [M_attr module](https://github.com/urbanjost/M_attr) for controlling ANSI-compatible terminals
 
-###### fortran-lang intrinsic descriptions (license: MIT) @urbanjost
+ _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_

--- a/source/learn/intrinsics/_pages/ACOS.md
+++ b/source/learn/intrinsics/_pages/ACOS.md
@@ -74,4 +74,4 @@ FORTRAN 77 and later; for a _complex_ argument - Fortran 2008 and later
 
 Inverse function: [**cos**(3](cos))
 
- _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_
+ _fortran-lang intrinsic descriptions (license: MIT) \@urbanjost_

--- a/source/learn/intrinsics/_pages/ACOS.md
+++ b/source/learn/intrinsics/_pages/ACOS.md
@@ -74,4 +74,4 @@ FORTRAN 77 and later; for a _complex_ argument - Fortran 2008 and later
 
 Inverse function: [**cos**(3](cos))
 
-###### fortran-lang intrinsic descriptions (license: MIT) @urbanjost
+ _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_

--- a/source/learn/intrinsics/_pages/ACOSH.md
+++ b/source/learn/intrinsics/_pages/ACOSH.md
@@ -64,4 +64,4 @@ Fortran 2008 and later
 
 Inverse function: [**cosh**(3)](#cosh)
 
- _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_
+ _fortran-lang intrinsic descriptions (license: MIT) \@urbanjost_

--- a/source/learn/intrinsics/_pages/ACOSH.md
+++ b/source/learn/intrinsics/_pages/ACOSH.md
@@ -64,4 +64,4 @@ Fortran 2008 and later
 
 Inverse function: [**cosh**(3)](#cosh)
 
-###### fortran-lang intrinsic descriptions (license: MIT) @urbanjost
+ _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_

--- a/source/learn/intrinsics/_pages/ADJUSTL.md
+++ b/source/learn/intrinsics/_pages/ADJUSTL.md
@@ -68,4 +68,4 @@ Fortran 95 and later
 
 [**adjustr**(3)](#adjustr)
 
- _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_
+ _fortran-lang intrinsic descriptions (license: MIT) \@urbanjost_

--- a/source/learn/intrinsics/_pages/ADJUSTL.md
+++ b/source/learn/intrinsics/_pages/ADJUSTL.md
@@ -68,4 +68,4 @@ Fortran 95 and later
 
 [**adjustr**(3)](#adjustr)
 
-###### fortran-lang intrinsic descriptions (license: MIT) @urbanjost
+ _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_

--- a/source/learn/intrinsics/_pages/ADJUSTR.md
+++ b/source/learn/intrinsics/_pages/ADJUSTR.md
@@ -79,4 +79,4 @@ Fortran 95 and later
 
 [**adjustl**(3)](#adjustl)
 
-###### fortran-lang intrinsic descriptions (license: MIT) @urbanjost
+ _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_

--- a/source/learn/intrinsics/_pages/ADJUSTR.md
+++ b/source/learn/intrinsics/_pages/ADJUSTR.md
@@ -79,4 +79,4 @@ Fortran 95 and later
 
 [**adjustl**(3)](#adjustl)
 
- _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_
+ _fortran-lang intrinsic descriptions (license: MIT) \@urbanjost_

--- a/source/learn/intrinsics/_pages/AIMAG.md
+++ b/source/learn/intrinsics/_pages/AIMAG.md
@@ -65,4 +65,4 @@ Results:
 
 FORTRAN 77 and later
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/AINT.md
+++ b/source/learn/intrinsics/_pages/AINT.md
@@ -95,4 +95,4 @@ FORTRAN 77 and later
 [**ceiling**(3)](#ceiling),
 [**floor**(3)](#floor)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/ALL.md
+++ b/source/learn/intrinsics/_pages/ALL.md
@@ -127,4 +127,4 @@ Case (ii):
 
 Fortran 95 and later
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/ALLOCATED.md
+++ b/source/learn/intrinsics/_pages/ALLOCATED.md
@@ -89,4 +89,4 @@ scalar entities are available in Fortran 2003 and later.
 
 [**move_alloc**(3)](#move_alloc)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/ANINT.md
+++ b/source/learn/intrinsics/_pages/ANINT.md
@@ -83,4 +83,4 @@ FORTRAN 77 and later
 [**ceiling**(3)](#ceiling),
 [**floor**(3)](#floor)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/ANY.md
+++ b/source/learn/intrinsics/_pages/ANY.md
@@ -75,4 +75,4 @@ Results:
 
 Fortran 95 and later
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/ASIN.md
+++ b/source/learn/intrinsics/_pages/ASIN.md
@@ -101,4 +101,4 @@ FORTRAN 77 and later, for a complex argument Fortran 2008 or later
 
 Inverse function: [**sin**(3)](#sin)
 
-###### fortran-lang intrinsic descriptions (license: MIT) @urbanjost
+ _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_

--- a/source/learn/intrinsics/_pages/ASIN.md
+++ b/source/learn/intrinsics/_pages/ASIN.md
@@ -101,4 +101,4 @@ FORTRAN 77 and later, for a complex argument Fortran 2008 or later
 
 Inverse function: [**sin**(3)](#sin)
 
- _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_
+ _fortran-lang intrinsic descriptions (license: MIT) \@urbanjost_

--- a/source/learn/intrinsics/_pages/ASINH.md
+++ b/source/learn/intrinsics/_pages/ASINH.md
@@ -62,4 +62,4 @@ Fortran 2008 and later
 
 Inverse function: [**sinh**(3)](#sinh)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/ASSOCIATED.md
+++ b/source/learn/intrinsics/_pages/ASSOCIATED.md
@@ -87,4 +87,4 @@ Fortran 95 and later
 
 [**null**(3)](#null)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/ATAN.md
+++ b/source/learn/intrinsics/_pages/ATAN.md
@@ -84,4 +84,4 @@ arguments Fortran 2008 or later
 
 [**atan2**(3)](#atan2), [**tan**(3)](#tan)
 
-###### fortran-lang intrinsic descriptions (license: MIT) @urbanjost
+ _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_

--- a/source/learn/intrinsics/_pages/ATAN.md
+++ b/source/learn/intrinsics/_pages/ATAN.md
@@ -84,4 +84,4 @@ arguments Fortran 2008 or later
 
 [**atan2**(3)](#atan2), [**tan**(3)](#tan)
 
- _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_
+ _fortran-lang intrinsic descriptions (license: MIT) \@urbanjost_

--- a/source/learn/intrinsics/_pages/ATAN2.md
+++ b/source/learn/intrinsics/_pages/ATAN2.md
@@ -66,4 +66,4 @@ Results:
 
 FORTRAN 77 and later
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/ATANH.md
+++ b/source/learn/intrinsics/_pages/ATANH.md
@@ -56,4 +56,4 @@ Fortran 2008 and later
 
 Inverse function: [**tanh**(3)](#tanh)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/ATOMIC_ADD.md
+++ b/source/learn/intrinsics/_pages/ATOMIC_ADD.md
@@ -59,4 +59,4 @@ TS 18508 or later
 [**atomic_xor**(3)](#atomic_xor)
 **iso_fortran_env**(3),
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/ATOMIC_AND.md
+++ b/source/learn/intrinsics/_pages/ATOMIC_AND.md
@@ -61,4 +61,4 @@ TS 18508 or later
 [**atomic_or**(3)](#atomic_or),
 [**atomic_xor**(3)](#atomic_xor)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/ATOMIC_CAS.md
+++ b/source/learn/intrinsics/_pages/ATOMIC_CAS.md
@@ -65,4 +65,4 @@ TS 18508 or later
 [**atomic_ref**(3)](#atomic_ref),
 [**iso_fortran_env**(3)](#)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/ATOMIC_DEFINE.md
+++ b/source/learn/intrinsics/_pages/ATOMIC_DEFINE.md
@@ -66,4 +66,4 @@ Fortran 2008 and later; with **stat**, TS 18508 or later
 [**atomic_or**(3)](#atomic_or),
 [**atomic_xor**(3)](#atomic_xor)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/ATOMIC_FETCH_ADD.md
+++ b/source/learn/intrinsics/_pages/ATOMIC_FETCH_ADD.md
@@ -65,4 +65,4 @@ TS 18508 or later
 
 [**atomic_fetch_xor**(3)](#atomic_fetch_xor)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/ATOMIC_FETCH_AND.md
+++ b/source/learn/intrinsics/_pages/ATOMIC_FETCH_AND.md
@@ -65,4 +65,4 @@ TS 18508 or later
 
 [**atomic_fetch_xor**(3)](#atomic_fetch_xor)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/ATOMIC_FETCH_OR.md
+++ b/source/learn/intrinsics/_pages/ATOMIC_FETCH_OR.md
@@ -65,4 +65,4 @@ TS 18508 or later
 
 [**atomic_fetch_xor**(3)](#atomic_fetch_xor)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/ATOMIC_FETCH_XOR.md
+++ b/source/learn/intrinsics/_pages/ATOMIC_FETCH_XOR.md
@@ -65,4 +65,4 @@ TS 18508 or later
 
 [**atomic_fetch_or**(3)](#atomic_fetch_or)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/ATOMIC_OR.md
+++ b/source/learn/intrinsics/_pages/ATOMIC_OR.md
@@ -61,4 +61,4 @@ TS 18508 or later
 
 [**atomic_xor**(3)](#atomic_xor)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/ATOMIC_REF.md
+++ b/source/learn/intrinsics/_pages/ATOMIC_REF.md
@@ -69,4 +69,4 @@ Fortran 2008 and later; with STAT, TS 18508 or later
 [**atomic_fetch_or**(3)](#atomic_or),
 [**atomic_fetch_xor**(3)](#atomic_xor)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/ATOMIC_XOR.md
+++ b/source/learn/intrinsics/_pages/ATOMIC_XOR.md
@@ -59,4 +59,4 @@ TS 18508 or later
 [**atomic_or**(3)](#atomic_or),
 [**atomic_xor**(3)](#atomic_xor)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/BESSEL_J0.md
+++ b/source/learn/intrinsics/_pages/BESSEL_J0.md
@@ -58,4 +58,4 @@ Fortran 2008 and later
 [**bessel_y1**(3)](#bessel_y1),
 [**bessel_yn**(3)](#bessel_yn)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/BESSEL_J1.md
+++ b/source/learn/intrinsics/_pages/BESSEL_J1.md
@@ -58,4 +58,4 @@ Fortran 2008 and later
 [**bessel_y1**(3)](#bessel_y1),
 [**bessel_yn**(3)](#bessel_yn)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/BESSEL_JN.md
+++ b/source/learn/intrinsics/_pages/BESSEL_JN.md
@@ -73,4 +73,4 @@ Fortran 2008 and later
 [**bessel_y1**(3)](#bessel_y1),
 [**bessel_yn**(3)](#bessel_yn)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/BESSEL_Y0.md
+++ b/source/learn/intrinsics/_pages/BESSEL_Y0.md
@@ -57,4 +57,4 @@ Fortran 2008 and later
 [**bessel_y1**(3)](#bessel_y1),
 [**bessel_yn**(3)](#bessel_yn)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/BESSEL_Y1.md
+++ b/source/learn/intrinsics/_pages/BESSEL_Y1.md
@@ -50,4 +50,4 @@ Fortran 2008 and later
 [**bessel_y0**(3)](#bessel_y0),
 [**bessel_yn**(3)](#bessel_yn)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/BESSEL_YN.md
+++ b/source/learn/intrinsics/_pages/BESSEL_YN.md
@@ -72,4 +72,4 @@ Fortran 2008 and later
 [**bessel_y0**(3)](#bessel_y0),
 [**bessel_y1**(3)](#bessel_y1)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/BGE.md
+++ b/source/learn/intrinsics/_pages/BGE.md
@@ -5,28 +5,99 @@
 **bge**(3) - \[BIT:COMPARE\] Bitwise greater than or equal to
 
 ### **Syntax**
-
 ```fortran
-    result = bge(i, j)
+    elemental function bge(i, j)
+
+     integer(kind=KIND),intent(in) :: i,j
+     logical :: bge
 ```
+where the _kind_ of **i** and **j** must be the same.
 
 ### **Description**
 
-Determines whether an integer is bitwise greater than or equal to
-another.
+  Determines whether an integer is bitwise greater than or equal to
+  another.
 
 ### **Arguments**
 
 - **i**
-  : Shall be of _integer_ type.
+  : The value to test if >= **j**
 
 - **j**
-  : Shall be of _integer_ type, and of the same kind as **i**.
+  : The value to test **i** against.
 
 ### **Returns**
 
-The return value is of type _logical_ and of the default kind.
+  The return value is of type _logical_ and of the default kind.
+  It is _.true._ if **i** is bit-wise greater than **j** and _.false._
+  otherwise.
 
+### **Examples**
+
+Sample program:
+```fortran
+program demo_bge
+use,intrinsic :: iso_fortran_env, only : int8, int16, int32, int64
+implicit none
+integer            :: i
+integer(kind=int8) :: byte
+integer(kind=int8),allocatable :: arr1(:), arr2(:)
+  ! basic usage
+   write(*,*)'bge(-127,127)=',bge( -127_int8, 127_int8 )
+   ! surprised -127 is great than 127 (on most machines, at least)?
+   ! if the values are not represented as "two's complement" or if
+   ! the endian changes the representation of a sign can vary!
+
+   write(*,*)'compare some values to 01000000 (64)'
+   write(*,*)'Notice that the values are tested as bits, so essentially'
+   write(*,*)'the values are tested as if unsigned integers.'
+   do i=-128,127,32
+      byte=i
+      write(*,'(sp,i0.4,*(1x,1l,1x,b0.8))')i,bge(byte,64_int8),byte
+   enddo
+  ! elemental
+
+   ! an array and scalar
+   write(*, *)'compare array of values [-128, -0, +0, 127] to 127'
+   write(*, *)bge(int([-128, -0, +0, 127], kind=int8), 127_int8)
+   ! are +0 and -9 the same?
+
+   ! two arrays
+   write(*, *)'compare two arrays'
+   arr1=int( [ -127, -0, +0,  127], kind=int8 )
+   arr2=int( [  127,  0,  0, -127], kind=int8 ) 
+   write(*,*)'arr1=',arr1
+   write(*,*)'arr2=',arr2
+   write(*, *)'bge(arr1,arr2)=',bge( arr1, arr2 )
+
+end program demo_bge
+```
+Results:
+
+  Note that how an integer value is represented at the bit level
+  can vary. These are just the values expected on the most common
+  platforms ...
+
+```text
+   >  bge(-127,127)= T
+   >  compare some values to 01000000 (64)
+   >  Notice that the values are tested as bits, so essentially
+   >  the values are tested as if unsigned integers.
+   > -0128  T 10000000
+   > -0096  T 10100000
+   > -0064  T 11000000
+   > -0032  T 11100000
+   > +0000  F 00000000
+   > +0032  F 00100000
+   > +0064  T 01000000
+   > +0096  T 01100000
+   >  compare array of values [-128, -0, +0, 127] to 127
+   >  T F F T
+   >  compare two arrays
+   >  arr1= -127    0    0  127
+   >  arr2=  127    0    0 -127
+   >  bge(arr1,arr2)= T T T F
+```
 ### **Standard**
 
 Fortran 2008 and later
@@ -37,4 +108,4 @@ Fortran 2008 and later
 [**ble**(3)](#ble),
 [**blt**(3)](#bit)
 
- _fortran-lang intrinsic descriptions_
+ _fortran-lang intrinsic descriptions \@urbanjost_

--- a/source/learn/intrinsics/_pages/BGE.md
+++ b/source/learn/intrinsics/_pages/BGE.md
@@ -104,7 +104,7 @@ integer(kind=int8),allocatable :: arr1(:), arr2(:)
    ! signs have ...
    write(*,*)'Compare some one-byte values to 64.'
    write(*,*)'Notice that the values are tested as bits not as integers'
-   write(*,*)'so the resuls are as if values are unsigned integers.'
+   write(*,*)'so the results are as if values are unsigned integers.'
    do i=-128,127,32
       byte=i
       write(*,'(sp,i0.4,*(1x,1l,1x,b0.8))')i,bge(byte,64_int8),byte

--- a/source/learn/intrinsics/_pages/BGE.md
+++ b/source/learn/intrinsics/_pages/BGE.md
@@ -8,23 +8,56 @@
 ```fortran
     elemental function bge(i, j)
 
-     integer(kind=KIND),intent(in) :: i,j
+     integer(kind=KIND),intent(in) :: i
+     integer(kind=KIND),intent(in) :: j
      logical :: bge
 ```
-where the _kind_ of **i** and **j** must be the same.
+where the _kind_ of **i** and **j** may be of any supported kind.
+An exception is that one value may be a BOZ constant with a
+value valid for the _kind_ of the _integer_ value.
 
 ### **Description**
 
-  Determines whether an integer is bitwise greater than or equal to
-  another.
+  Determines whether one _integer_ is bitwise greater than or equal
+  to another.
+
+  The bit-level representation of a value is platform dependent. The
+  endian-ness of a system and whether the system uses a "two's complement"
+  representation of signs can affect the results, for example.
+
+  A BOZ constant (Binary, Octal, Hexadecimal) does not have a _kind_
+  or _type_ of its own, so be aware it is subject to truncation when
+  transferred to the _kind_ and _type_ of the other argument.
+
+  Positions of bits in the sequence are numbered from right to left, with
+  the position of the rightmost bit being zero.  The bits are evaluated
+  in this order, not necessarily from MSB to LSB (most significant bit
+  to least significant bit).
+
+#### Bit Sequence Comparison
+
+  When bit sequences of unequal length are compared, the shorter sequence
+  is padded with zero bits on the left to the same length as the longer
+  sequence.
+
+  Bit sequences are compared from left to right, one bit at a time,
+  until unequal bits are found or until all bits have been compared and
+  found to be equal.
+
+  If unequal bits are found the sequence with zero in the unequal
+  position is considered to be less than the sequence with one in the
+  unequal position.
 
 ### **Arguments**
 
 - **i**
-  : The value to test if >= **j**
+  : The value to test if >= **j** based on the bit representation
+    of the values.
+    Shall be of _integer_ type or a BOZ literal constant.
 
 - **j**
   : The value to test **i** against.
+    Shall be of _integer_ type or a BOZ literal constant.
 
 ### **Returns**
 
@@ -42,25 +75,21 @@ implicit none
 integer            :: i
 integer(kind=int8) :: byte
 integer(kind=int8),allocatable :: arr1(:), arr2(:)
-  ! basic usage
-   write(*,*)'bge(-127,127)=',bge( -127_int8, 127_int8 )
-   ! surprised -127 is great than 127 (on most machines, at least)?
-   ! if the values are not represented as "two's complement" or if
-   ! the endian changes the representation of a sign can vary!
 
-   write(*,*)'compare some values to 01000000 (64)'
-   write(*,*)'Notice that the values are tested as bits, so essentially'
-   write(*,*)'the values are tested as if unsigned integers.'
-   do i=-128,127,32
-      byte=i
-      write(*,'(sp,i0.4,*(1x,1l,1x,b0.8))')i,bge(byte,64_int8),byte
-   enddo
-  ! elemental
+  ! BASIC USAGE
+   write(*,*)'bge(-127,127)=',bge( -127, 127 )
+   ! on (very common) "two's complement" machines that are 
+   ! little-endian -127 will be greater than 127
 
+   ! BOZ constants
+   ! BOZ constants are subject to truncation, so make sure
+   ! your values are valid for the integer kind being compared to
+   write(*,*)'bge(b"0001",2)=',bge( b"1", 2)
+
+  ! ELEMENTAL
    ! an array and scalar
    write(*, *)'compare array of values [-128, -0, +0, 127] to 127'
    write(*, *)bge(int([-128, -0, +0, 127], kind=int8), 127_int8)
-   ! are +0 and -9 the same?
 
    ! two arrays
    write(*, *)'compare two arrays'
@@ -70,33 +99,52 @@ integer(kind=int8),allocatable :: arr1(:), arr2(:)
    write(*,*)'arr2=',arr2
    write(*, *)'bge(arr1,arr2)=',bge( arr1, arr2 )
 
+  ! SHOW TESTS AND BITS
+   ! actually looking at the bit patterns should clarify what affect
+   ! signs have ...
+   write(*,*)'Compare some one-byte values to 64.'
+   write(*,*)'Notice that the values are tested as bits not as integers'
+   write(*,*)'so the resuls are as if values are unsigned integers.'
+   do i=-128,127,32
+      byte=i
+      write(*,'(sp,i0.4,*(1x,1l,1x,b0.8))')i,bge(byte,64_int8),byte
+   enddo
+
+  ! SIGNED ZERO
+   ! are +0 and -0 the same on your platform? When comparing at the
+   ! bit level this is important
+   write(*,'("plus zero=",b0)')  +0
+   write(*,'("minus zero=",b0)') -0
+
 end program demo_bge
 ```
 Results:
 
-  Note that how an integer value is represented at the bit level
-  can vary. These are just the values expected on the most common
-  platforms ...
+  How an integer value is represented at the bit level can vary. These
+  are just the values expected on Today's most common platforms ...
 
 ```text
-   >  bge(-127,127)= T
-   >  compare some values to 01000000 (64)
-   >  Notice that the values are tested as bits, so essentially
-   >  the values are tested as if unsigned integers.
-   > -0128  T 10000000
-   > -0096  T 10100000
-   > -0064  T 11000000
-   > -0032  T 11100000
-   > +0000  F 00000000
-   > +0032  F 00100000
-   > +0064  T 01000000
-   > +0096  T 01100000
-   >  compare array of values [-128, -0, +0, 127] to 127
-   >  T F F T
-   >  compare two arrays
-   >  arr1= -127    0    0  127
-   >  arr2=  127    0    0 -127
-   >  bge(arr1,arr2)= T T T F
+    > bge(-127,127)= T
+    > bge(b"0001",2)= F
+    > compare array of values [-128, -0, +0, 127] to 127
+    > T F F T
+    > compare two arrays
+    > arr1= -127    0    0  127
+    > arr2=  127    0    0 -127
+    > bge(arr1,arr2)= T T T F
+    > Compare some one-byte values to 64.
+    > Notice that the values are tested as bits not as integers
+    > so the resuls are as if values are unsigned integers.
+    > -0128  T 10000000
+    > -0096  T 10100000
+    > -0064  T 11000000
+    > -0032  T 11100000
+    > +0000  F 00000000
+    > +0032  F 00100000
+    > +0064  T 01000000
+    > +0096  T 01100000
+    > plus zero=0
+    > minus zero=0
 ```
 ### **Standard**
 
@@ -106,6 +154,6 @@ Fortran 2008 and later
 
 [**bgt**(3)](#bgt),
 [**ble**(3)](#ble),
-[**blt**(3)](#bit)
+[**blt**(3)](#blt)
 
  _fortran-lang intrinsic descriptions \@urbanjost_

--- a/source/learn/intrinsics/_pages/BGE.md
+++ b/source/learn/intrinsics/_pages/BGE.md
@@ -37,4 +37,4 @@ Fortran 2008 and later
 [**ble**(3)](#ble),
 [**blt**(3)](#bit)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/BGE.md
+++ b/source/learn/intrinsics/_pages/BGE.md
@@ -12,9 +12,10 @@
      integer(kind=KIND),intent(in) :: j
      logical :: bge
 ```
-where the _kind_ of **i** and **j** may be of any supported kind.
-An exception is that one value may be a BOZ constant with a
-value valid for the _kind_ of the _integer_ value.
+  where the _kind_ of **i** and **j** may be of any supported _integer_
+  kind, not necessarily the same.  An exception is that values may be a
+  BOZ constant with a value valid for the _integer_ kind available with
+  the most bits on the current platform.
 
 ### **Description**
 
@@ -27,22 +28,24 @@ value valid for the _kind_ of the _integer_ value.
 
   A BOZ constant (Binary, Octal, Hexadecimal) does not have a _kind_
   or _type_ of its own, so be aware it is subject to truncation when
-  transferred to the _kind_ and _type_ of the other argument.
+  transferred to an _integer_ type. The most bits the constant may
+  contain is limited by the most bits representable by any _integer_
+  kind supported by the compilation.
 
-  Positions of bits in the sequence are numbered from right to left, with
-  the position of the rightmost bit being zero.  The bits are evaluated
-  in this order, not necessarily from MSB to LSB (most significant bit
-  to least significant bit).
 
 #### Bit Sequence Comparison
 
   When bit sequences of unequal length are compared, the shorter sequence
   is padded with zero bits on the left to the same length as the longer
-  sequence.
+  sequence (up to the largest number of bits any available _integer_ kind
+  supports).
 
   Bit sequences are compared from left to right, one bit at a time,
   until unequal bits are found or until all bits have been compared and
   found to be equal.
+
+  The bits are always evaluated in this order, not necessarily from MSB
+  to LSB (most significant bit to least significant bit).
 
   If unequal bits are found the sequence with zero in the unequal
   position is considered to be less than the sequence with one in the
@@ -156,4 +159,4 @@ Fortran 2008 and later
 [**ble**(3)](#ble),
 [**blt**(3)](#blt)
 
- _fortran-lang intrinsic descriptions \@urbanjost_
+ _fortran-lang intrinsic descriptions (license: MIT) \@urbanjost_

--- a/source/learn/intrinsics/_pages/BGT.md
+++ b/source/learn/intrinsics/_pages/BGT.md
@@ -5,14 +5,21 @@
 **bgt**(3) - \[BIT:COMPARE\] Bitwise greater than
 
 ### **Syntax**
-
 ```fortran
-    result = bgt(i, j)
+    elemental function bgt(i, j)
+
+     integer(kind=KIND),intent(in) :: i
+     integer(kind=KIND),intent(in) :: j
+     logical :: bgt
 ```
+where the _kind_ of **i** and **j** may be of any supported kind.
+An exception is that one value may be a BOZ constant with a
+value valid for the _kind_ of the _integer_ value.
 
 ### **Description**
 
 Determines whether an integer is bitwise greater than another.
+Bit-level representations of values are platform-dependent.
 
 ### **Arguments**
 
@@ -20,8 +27,7 @@ Determines whether an integer is bitwise greater than another.
   : Shall be of _integer_ type or a BOZ literal constant.
 
 - **j**
-  : Shall be of _integer_ type, and of the same kind as **i**; or a BOZ
-  literal constant.
+  : Shall be of _integer_ type or a BOZ literal constant.
 
 ### **Returns**
 
@@ -29,6 +35,38 @@ The return value is of type _logical_ and of the default kind. The result
 is true if the sequence of bits represented by _i_ is greater than the
 sequence of bits represented by _j_, otherwise the result is false.
 
+### **Examples**
+
+Sample program:
+```fortran
+program demo_bgt
+use,intrinsic :: iso_fortran_env, only : int8, int16, int32, int64
+implicit none
+integer            :: i
+integer(kind=int8) :: byte
+  ! Compare some one-byte values to 64.
+   ! Notice that the values are tested as bits not as integers
+   ! so sign bits in the integer are treated just like any other
+   do i=-128,127,32
+      byte=i
+      write(*,'(sp,i0.4,*(1x,1l,1x,b0.8))')i,bgt(byte,64_int8),byte
+   enddo
+
+   ! see the BGE() description for an extended example
+
+end program demo_bgt
+```
+Results:
+```text
+   > -0128  T 10000000
+   > -0096  T 10100000
+   > -0064  T 11000000
+   > -0032  T 11100000
+   > +0000  F 00000000
+   > +0032  F 00100000
+   > +0064  F 01000000
+   > +0096  T 01100000
+```
 ### **Standard**
 
 Fortran 2008 and later
@@ -39,4 +77,4 @@ Fortran 2008 and later
 [**ble**(3)](#ble),
 [**blt**(3)](#blt)
 
- _fortran-lang intrinsic descriptions_
+ _fortran-lang intrinsic descriptions \@urbanjost_

--- a/source/learn/intrinsics/_pages/BGT.md
+++ b/source/learn/intrinsics/_pages/BGT.md
@@ -12,14 +12,15 @@
      integer(kind=KIND),intent(in) :: j
      logical :: bgt
 ```
-where the _kind_ of **i** and **j** may be of any supported kind.
-An exception is that one value may be a BOZ constant with a
-value valid for the _kind_ of the _integer_ value.
+  where the _kind_ of **i** and **j** may be of any supported _integer_
+  kind, not necessarily the same.  An exception is that values may be a
+  BOZ constant with a value valid for the _integer_ kind available with
+  the most bits on the current platform.
 
 ### **Description**
 
-Determines whether an integer is bitwise greater than another.
-Bit-level representations of values are platform-dependent.
+  Determines whether an integer is bitwise greater than another.
+  Bit-level representations of values are platform-dependent.
 
 ### **Arguments**
 
@@ -31,9 +32,10 @@ Bit-level representations of values are platform-dependent.
 
 ### **Returns**
 
-The return value is of type _logical_ and of the default kind. The result
-is true if the sequence of bits represented by _i_ is greater than the
-sequence of bits represented by _j_, otherwise the result is false.
+  The return value is of type _logical_ and of the default kind. The
+  result is true if the sequence of bits represented by _i_ is greater
+  than the sequence of bits represented by _j_, otherwise the result
+  is false.
 
 ### **Examples**
 
@@ -52,7 +54,8 @@ integer(kind=int8) :: byte
       write(*,'(sp,i0.4,*(1x,1l,1x,b0.8))')i,bgt(byte,64_int8),byte
    enddo
 
-   ! see the BGE() description for an extended example
+   ! see the BGE() description for an extended description 
+   ! of related information
 
 end program demo_bgt
 ```
@@ -77,4 +80,4 @@ Fortran 2008 and later
 [**ble**(3)](#ble),
 [**blt**(3)](#blt)
 
- _fortran-lang intrinsic descriptions \@urbanjost_
+ _fortran-lang intrinsic descriptions (license: MIT) \@urbanjost_

--- a/source/learn/intrinsics/_pages/BGT.md
+++ b/source/learn/intrinsics/_pages/BGT.md
@@ -39,4 +39,4 @@ Fortran 2008 and later
 [**ble**(3)](#ble),
 [**blt**(3)](#blt)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/BIT_SIZE.md
+++ b/source/learn/intrinsics/_pages/BIT_SIZE.md
@@ -67,4 +67,4 @@ Typical Results:
 
 Fortran 95 and later
 
-###### fortran-lang intrinsic descriptions (license: MIT) @urbanjost
+ _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_

--- a/source/learn/intrinsics/_pages/BIT_SIZE.md
+++ b/source/learn/intrinsics/_pages/BIT_SIZE.md
@@ -67,4 +67,4 @@ Typical Results:
 
 Fortran 95 and later
 
- _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_
+ _fortran-lang intrinsic descriptions (license: MIT) \@urbanjost_

--- a/source/learn/intrinsics/_pages/BIT_index.md
+++ b/source/learn/intrinsics/_pages/BIT_index.md
@@ -49,4 +49,4 @@ permalink: /learn/intrinsics/BIT_index
 | _BIT:SHIFT_ ||||| [**shiftr**]({{site.baseurl}}/learn/intrinsics/SHIFTR) || &#9679; Shift bits right |
 |----------------|||||----------------------------------------------------------------------||------------------------------------------------------|
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/BLE.md
+++ b/source/learn/intrinsics/_pages/BLE.md
@@ -5,10 +5,17 @@
 **ble**(3) - \[BIT:COMPARE\] Bitwise less than or equal to
 
 ### **Syntax**
-
 ```fortran
-    result = ble(i, j)
+    elemental function ble(i, j)
+
+     integer(kind=KIND),intent(in) :: i
+     integer(kind=KIND),intent(in) :: j
+     logical :: ble
 ```
+where the _kind_ of **i** and **j** may be of any supported kind.
+An exception is that one value may be a BOZ constant with a
+value valid for the _kind_ of the _integer_ value.
+### **Syntax**
 
 ### **Description**
 
@@ -17,15 +24,46 @@ Determines whether an integer is bitwise less than or equal to another.
 ### **Arguments**
 
 - **i**
-  : Shall be of _integer_ type.
+  : Shall be of _integer_ type or a BOZ literal constant.
 
 - **j**
-  : Shall be of _integer_ type, and of the same kind as **i**.
+  : Shall be of _integer_ type or a BOZ constant.
 
 ### **Returns**
 
 The return value is of type _logical_ and of the default kind.
+### **Examples**
 
+Sample program:
+```fortran
+program demo_ble
+use,intrinsic :: iso_fortran_env, only : int8, int16, int32, int64
+implicit none
+integer            :: i
+integer(kind=int8) :: byte
+  ! Compare some one-byte values to 64.
+   ! Notice that the values are tested as bits not as integers
+   ! so sign bits in the integer are treated just like any other
+   do i=-128,127,32
+      byte=i
+      write(*,'(sp,i0.4,*(1x,1l,1x,b0.8))')i,ble(byte,64_int8),byte
+   enddo
+
+   ! see the BGE() description for an extended example
+
+end program demo_ble
+```
+Results:
+```text
+   > -0128  F 10000000
+   > -0096  F 10100000
+   > -0064  F 11000000
+   > -0032  F 11100000
+   > +0000  T 00000000
+   > +0032  T 00100000
+   > +0064  T 01000000
+   > +0096  F 01100000
+```
 ### **Standard**
 
 Fortran 2008 and later
@@ -36,4 +74,4 @@ Fortran 2008 and later
 [**bgt**(3)](#bgt),
 [**blt**(3)](#blt)
 
- _fortran-lang intrinsic descriptions_
+ _fortran-lang intrinsic descriptions \@urbanjost_

--- a/source/learn/intrinsics/_pages/BLE.md
+++ b/source/learn/intrinsics/_pages/BLE.md
@@ -12,9 +12,11 @@
      integer(kind=KIND),intent(in) :: j
      logical :: ble
 ```
-where the _kind_ of **i** and **j** may be of any supported kind.
-An exception is that one value may be a BOZ constant with a
-value valid for the _kind_ of the _integer_ value.
+  where the _kind_ of **i** and **j** may be of any supported _integer_
+  kind, not necessarily the same.  An exception is that values may be a
+  BOZ constant with a value valid for the _integer_ kind available with
+  the most bits on the current platform.
+
 ### **Syntax**
 
 ### **Description**
@@ -49,7 +51,8 @@ integer(kind=int8) :: byte
       write(*,'(sp,i0.4,*(1x,1l,1x,b0.8))')i,ble(byte,64_int8),byte
    enddo
 
-   ! see the BGE() description for an extended example
+   ! see the BGE() description for an extended description 
+   ! of related information
 
 end program demo_ble
 ```
@@ -74,4 +77,4 @@ Fortran 2008 and later
 [**bgt**(3)](#bgt),
 [**blt**(3)](#blt)
 
- _fortran-lang intrinsic descriptions \@urbanjost_
+ _fortran-lang intrinsic descriptions (license: MIT) \@urbanjost_

--- a/source/learn/intrinsics/_pages/BLE.md
+++ b/source/learn/intrinsics/_pages/BLE.md
@@ -36,4 +36,4 @@ Fortran 2008 and later
 [**bgt**(3)](#bgt),
 [**blt**(3)](#blt)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/BLT.md
+++ b/source/learn/intrinsics/_pages/BLT.md
@@ -3,13 +3,17 @@
 ### **Name**
 
 **blt**(3) - \[BIT:COMPARE\] Bitwise less than
-
 ### **Syntax**
-
 ```fortran
-    result = blt(i, j)
-```
+    elemental function blt(i, j)
 
+     integer(kind=KIND),intent(in) :: i
+     integer(kind=KIND),intent(in) :: j
+     logical :: blt
+```
+where the _kind_ of **i** and **j** may be of any supported kind.
+An exception is that one value may be a BOZ constant with a
+value valid for the _kind_ of the _integer_ value.
 ### **Description**
 
 Determines whether an integer is bitwise less than another.
@@ -17,15 +21,46 @@ Determines whether an integer is bitwise less than another.
 ### **Arguments**
 
 - **i**
-  : Shall be of _integer_ type.
+    Shall be of _integer_ type or a BOZ literal constant.
 
 - **j**
-  : Shall be of _integer_ type, and of the same kind as **i**.
+  : Shall be of _integer_ type or a BOZ constant.
 
 ### **Returns**
 
 The return value is of type _logical_ and of the default kind.
+### **Examples**
 
+Sample program:
+```fortran
+program demo_blt
+use,intrinsic :: iso_fortran_env, only : int8, int16, int32, int64
+implicit none
+integer            :: i
+integer(kind=int8) :: byte
+  ! Compare some one-byte values to 64.
+   ! Notice that the values are tested as bits not as integers
+   ! so sign bits in the integer are treated just like any other
+   do i=-128,127,32
+      byte=i
+      write(*,'(sp,i0.4,*(1x,1l,1x,b0.8))')i,blt(byte,64_int8),byte
+   enddo
+
+   ! see the BGE() description for an extended example
+
+end program demo_blt
+```
+Results:
+```text
+   > -0128  F 10000000
+   > -0096  F 10100000
+   > -0064  F 11000000
+   > -0032  F 11100000
+   > +0000  T 00000000
+   > +0032  T 00100000
+   > +0064  F 01000000
+   > +0096  F 01100000
+```
 ### **Standard**
 
 Fortran 2008 and later
@@ -36,4 +71,4 @@ Fortran 2008 and later
 [**bgt**(3)](#bgt),
 [**ble**(3)](#ble)
 
- _fortran-lang intrinsic descriptions_
+ _fortran-lang intrinsic descriptions \@urbanjost_

--- a/source/learn/intrinsics/_pages/BLT.md
+++ b/source/learn/intrinsics/_pages/BLT.md
@@ -3,6 +3,7 @@
 ### **Name**
 
 **blt**(3) - \[BIT:COMPARE\] Bitwise less than
+
 ### **Syntax**
 ```fortran
     elemental function blt(i, j)
@@ -11,9 +12,11 @@
      integer(kind=KIND),intent(in) :: j
      logical :: blt
 ```
-where the _kind_ of **i** and **j** may be of any supported kind.
-An exception is that one value may be a BOZ constant with a
-value valid for the _kind_ of the _integer_ value.
+  where the _kind_ of **i** and **j** may be of any supported _integer_
+  kind, not necessarily the same.  An exception is that values may be a
+  BOZ constant with a value valid for the _integer_ kind available with
+  the most bits on the current platform.
+
 ### **Description**
 
 Determines whether an integer is bitwise less than another.
@@ -29,6 +32,7 @@ Determines whether an integer is bitwise less than another.
 ### **Returns**
 
 The return value is of type _logical_ and of the default kind.
+
 ### **Examples**
 
 Sample program:
@@ -46,7 +50,8 @@ integer(kind=int8) :: byte
       write(*,'(sp,i0.4,*(1x,1l,1x,b0.8))')i,blt(byte,64_int8),byte
    enddo
 
-   ! see the BGE() description for an extended example
+   ! see the BGE() description for an extended description 
+   ! of related information
 
 end program demo_blt
 ```
@@ -71,4 +76,4 @@ Fortran 2008 and later
 [**bgt**(3)](#bgt),
 [**ble**(3)](#ble)
 
- _fortran-lang intrinsic descriptions \@urbanjost_
+ _fortran-lang intrinsic descriptions (license: MIT) \@urbanjost_

--- a/source/learn/intrinsics/_pages/BLT.md
+++ b/source/learn/intrinsics/_pages/BLT.md
@@ -36,4 +36,4 @@ Fortran 2008 and later
 [**bgt**(3)](#bgt),
 [**ble**(3)](#ble)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/BTEST.md
+++ b/source/learn/intrinsics/_pages/BTEST.md
@@ -133,4 +133,4 @@ Fortran 95 and later
 [**ieor**(3)](#ieor),
 [**mvbits**(3)](#mvbits)
 
- _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_
+ _fortran-lang intrinsic descriptions (license: MIT) \@urbanjost_

--- a/source/learn/intrinsics/_pages/BTEST.md
+++ b/source/learn/intrinsics/_pages/BTEST.md
@@ -133,4 +133,4 @@ Fortran 95 and later
 [**ieor**(3)](#ieor),
 [**mvbits**(3)](#mvbits)
 
-###### fortran-lang intrinsic descriptions (license: MIT) @urbanjost
+ _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_

--- a/source/learn/intrinsics/_pages/CEILING.md
+++ b/source/learn/intrinsics/_pages/CEILING.md
@@ -78,4 +78,4 @@ Fortran 95 and later
 [**int**(3)](#int),
 [**selected_int_kind**(3)](#selected_int_kind)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/CHAR.md
+++ b/source/learn/intrinsics/_pages/CHAR.md
@@ -78,4 +78,4 @@ of arguments, and search for certain arguments:
   [**len**(3)](#len),
   [**repeat**(3)](#repeat), [**trim**(3)](#trim)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/CMPLX.md
+++ b/source/learn/intrinsics/_pages/CMPLX.md
@@ -162,4 +162,4 @@ Typical Results:
 
 FORTRAN 77 and later
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/COMMAND_ARGUMENT_COUNT.md
+++ b/source/learn/intrinsics/_pages/COMMAND_ARGUMENT_COUNT.md
@@ -63,4 +63,4 @@ Fortran 2003 and later
 [**get_command**(3)](#get_command),
 [**get_command_argument**(3)](#get_command_argument)
 
-###### fortran-lang intrinsic descriptions (license: MIT) @urbanjost
+ _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_

--- a/source/learn/intrinsics/_pages/COMMAND_ARGUMENT_COUNT.md
+++ b/source/learn/intrinsics/_pages/COMMAND_ARGUMENT_COUNT.md
@@ -63,4 +63,4 @@ Fortran 2003 and later
 [**get_command**(3)](#get_command),
 [**get_command_argument**(3)](#get_command_argument)
 
- _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_
+ _fortran-lang intrinsic descriptions (license: MIT) \@urbanjost_

--- a/source/learn/intrinsics/_pages/COMPILER_OPTIONS.md
+++ b/source/learn/intrinsics/_pages/COMPILER_OPTIONS.md
@@ -60,4 +60,4 @@ Fortran 2008
 [**compiler_version**(3)](#compiler_version),
 **iso_fortran_env**(7)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/COMPILER_VERSION.md
+++ b/source/learn/intrinsics/_pages/COMPILER_VERSION.md
@@ -60,4 +60,4 @@ Fortran 2008
 [**compiler_options**(3)](#compiler_options),
 **iso_fortran_env**(7)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/CONJG.md
+++ b/source/learn/intrinsics/_pages/CONJG.md
@@ -102,4 +102,4 @@ Results:
 
 FORTRAN 77 and later
 
-###### fortran-lang intrinsic descriptions (license: MIT) @urbanjost
+ _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_

--- a/source/learn/intrinsics/_pages/CONJG.md
+++ b/source/learn/intrinsics/_pages/CONJG.md
@@ -102,4 +102,4 @@ Results:
 
 FORTRAN 77 and later
 
- _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_
+ _fortran-lang intrinsic descriptions (license: MIT) \@urbanjost_

--- a/source/learn/intrinsics/_pages/COS.md
+++ b/source/learn/intrinsics/_pages/COS.md
@@ -79,4 +79,4 @@ FORTRAN 77 and later
 [**sin**(3)](#sin),
 [**tan**(3)](#tan)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/COSH.md
+++ b/source/learn/intrinsics/_pages/COSH.md
@@ -58,4 +58,4 @@ FORTRAN 77 and later, for a complex argument - Fortran 2008 or later
 
 Inverse function: [**acosh**(3)](#acosh)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/COUNT.md
+++ b/source/learn/intrinsics/_pages/COUNT.md
@@ -89,4 +89,4 @@ Expected Results:
 Fortran 95 and later, with KIND argument - Fortran 2003
 and later
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/CO_BROADCAST.md
+++ b/source/learn/intrinsics/_pages/CO_BROADCAST.md
@@ -59,4 +59,4 @@ end program demo_co_broadcast
 [**co_sum**(3)](#co_sum),
 [**co_reduce**(3)](#co_reduce)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/CO_LBOUND.md
+++ b/source/learn/intrinsics/_pages/CO_LBOUND.md
@@ -44,4 +44,4 @@ Fortran 2008 and later
 [**co_ubound**(3)](#co_ubound),
 [**lbound**(3)](#lbound)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/CO_MAX.md
+++ b/source/learn/intrinsics/_pages/CO_MAX.md
@@ -71,4 +71,4 @@ TS 18508 or later
 [**co_reduce**(3)](#co_reduce),
 [**co_broadcast**(3)](#co_broadcast)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/CO_MIN.md
+++ b/source/learn/intrinsics/_pages/CO_MIN.md
@@ -65,4 +65,4 @@ TS 18508 or later
 [**co_reduce**(3)](#co_reduce),
 [**co_broadcast**(3)](#co_broadcast)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/CO_REDUCE.md
+++ b/source/learn/intrinsics/_pages/CO_REDUCE.md
@@ -99,4 +99,4 @@ TS 18508 or later
 [**co_sum**(3)](#co_sum),
 [**co_broadcast**(3)](#co_broadcast)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/CO_SUM.md
+++ b/source/learn/intrinsics/_pages/CO_SUM.md
@@ -72,4 +72,4 @@ TS 18508 or later
 [**co_reduce**(3)](#co_reduce),
 [**co_broadcast**(3)](#co_broadcast)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/CO_UBOUND.md
+++ b/source/learn/intrinsics/_pages/CO_UBOUND.md
@@ -45,4 +45,4 @@ Fortran 2008 and later
 [**lbound**(3)](#lbound),
 [**ubound**(3)](#ubound)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/CPU_TIME.md
+++ b/source/learn/intrinsics/_pages/CPU_TIME.md
@@ -75,4 +75,4 @@ Fortran 95 and later
 [**system_clock**(3)](#system_clock),
 [**date_and_time**(3)](#date_and_time)
 
- _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_
+ _fortran-lang intrinsic descriptions (license: MIT) \@urbanjost_

--- a/source/learn/intrinsics/_pages/CPU_TIME.md
+++ b/source/learn/intrinsics/_pages/CPU_TIME.md
@@ -75,4 +75,4 @@ Fortran 95 and later
 [**system_clock**(3)](#system_clock),
 [**date_and_time**(3)](#date_and_time)
 
-###### fortran-lang intrinsic descriptions (license: MIT) @urbanjost
+ _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_

--- a/source/learn/intrinsics/_pages/CSHIFT.md
+++ b/source/learn/intrinsics/_pages/CSHIFT.md
@@ -72,4 +72,4 @@ Results:
 
 Fortran 95 and later
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/C_ASSOCIATED.md
+++ b/source/learn/intrinsics/_pages/C_ASSOCIATED.md
@@ -61,4 +61,4 @@ Fortran 2003 and later
 [**c_funloc**(3)](#c_funloc),
 **iso_c_binding**(3)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/C_FUNLOC.md
+++ b/source/learn/intrinsics/_pages/C_FUNLOC.md
@@ -68,4 +68,4 @@ Fortran 2003 and later
 [**c_f_procpointer**(3)](#c_f_procpointer),
 **iso_c_binding**(3)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/C_F_POINTER.md
+++ b/source/learn/intrinsics/_pages/C_F_POINTER.md
@@ -59,4 +59,4 @@ Fortran 2003 and later
 [**c_f_procpointer**(3)](#c_f_procpointer),
 **iso_c_binding**(3)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/C_F_PROCPOINTER.md
+++ b/source/learn/intrinsics/_pages/C_F_PROCPOINTER.md
@@ -61,4 +61,4 @@ Fortran 2003 and later
 [**c_f_pointer**(3)](#c_f_pointer),
 **iso_c_binding**(3)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/C_LOC.md
+++ b/source/learn/intrinsics/_pages/C_LOC.md
@@ -55,4 +55,4 @@ Fortran 2003 and later
 [**c_f_procpointer**(3)](#c_f_procpointer),
 **iso_c_binding**(3)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/C_SIZEOF.md
+++ b/source/learn/intrinsics/_pages/C_SIZEOF.md
@@ -60,4 +60,4 @@ Fortran 2008
 
 [**storage_size**(3)](#storage_size)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/DATE_AND_TIME.md
+++ b/source/learn/intrinsics/_pages/DATE_AND_TIME.md
@@ -108,4 +108,4 @@ date and time conversion, formatting and computation
 - [datetime](https://github.com/wavebitscientific/datetime-fortran)
 - [datetime-fortran](https://github.com/wavebitscientific/datetime-fortran)
 
- _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_
+ _fortran-lang intrinsic descriptions (license: MIT) \@urbanjost_

--- a/source/learn/intrinsics/_pages/DATE_AND_TIME.md
+++ b/source/learn/intrinsics/_pages/DATE_AND_TIME.md
@@ -108,4 +108,4 @@ date and time conversion, formatting and computation
 - [datetime](https://github.com/wavebitscientific/datetime-fortran)
 - [datetime-fortran](https://github.com/wavebitscientific/datetime-fortran)
 
-###### fortran-lang intrinsic descriptions (license: MIT) @urbanjost
+ _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_

--- a/source/learn/intrinsics/_pages/DBLE.md
+++ b/source/learn/intrinsics/_pages/DBLE.md
@@ -61,4 +61,4 @@ FORTRAN 77 and later
 [**float**(3)](#float),
 [**real**(3)](#real)
 
- _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_
+ _fortran-lang intrinsic descriptions (license: MIT) \@urbanjost_

--- a/source/learn/intrinsics/_pages/DBLE.md
+++ b/source/learn/intrinsics/_pages/DBLE.md
@@ -61,4 +61,4 @@ FORTRAN 77 and later
 [**float**(3)](#float),
 [**real**(3)](#real)
 
-###### fortran-lang intrinsic descriptions (license: MIT) @urbanjost
+ _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_

--- a/source/learn/intrinsics/_pages/DIGITS.md
+++ b/source/learn/intrinsics/_pages/DIGITS.md
@@ -77,4 +77,4 @@ Fortran 95 and later
 [**spacing**(3)](#spacing),
 [**tiny**(3)](#tiny)
 
- _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_
+ _fortran-lang intrinsic descriptions (license: MIT) \@urbanjost_

--- a/source/learn/intrinsics/_pages/DIGITS.md
+++ b/source/learn/intrinsics/_pages/DIGITS.md
@@ -77,4 +77,4 @@ Fortran 95 and later
 [**spacing**(3)](#spacing),
 [**tiny**(3)](#tiny)
 
-###### fortran-lang intrinsic descriptions (license: MIT) @urbanjost
+ _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_

--- a/source/learn/intrinsics/_pages/DIM.md
+++ b/source/learn/intrinsics/_pages/DIM.md
@@ -68,4 +68,4 @@ Results:
 
 FORTRAN 77 and later
 
- _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_
+ _fortran-lang intrinsic descriptions (license: MIT) \@urbanjost_

--- a/source/learn/intrinsics/_pages/DIM.md
+++ b/source/learn/intrinsics/_pages/DIM.md
@@ -68,4 +68,4 @@ Results:
 
 FORTRAN 77 and later
 
-###### fortran-lang intrinsic descriptions (license: MIT) @urbanjost
+ _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_

--- a/source/learn/intrinsics/_pages/DOT_PRODUCT.md
+++ b/source/learn/intrinsics/_pages/DOT_PRODUCT.md
@@ -68,4 +68,4 @@ Results:
 
 Fortran 95 and later
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/DPROD.md
+++ b/source/learn/intrinsics/_pages/DPROD.md
@@ -2,44 +2,43 @@
 
 ### **Name**
 
-**dprod**(3) - \[NUMERIC\] Double product function
+**dprod**(3) - \[NUMERIC\] Double precision real product
 
 ### **Syntax**
 
 ```fortran
-result = dprod(x, y)
-```
+   elemental function dprod(x,y)
 
+    real,intent(in) :: x
+    real,intent(in) :: y
+    doubleprecision :: dprod
+```
 ### **Description**
 
-**dprod(x,y)** produces a higher _doubleprecision_ product of default _real_
-numbers **x** and **y**.
+**dprod(x,y)** produces a _doubleprecision_ product of default _real_
+values **x** and **y**.
 
 The result has a value equal to a processor-dependent approximation to
-the product of **x** and **y**. It is recommended that the processor compute the
-product in double precision, rather than in single precision and then
-converted to double precision.
-
-- **x**
-  : shall be default real.
-
-- **y**
-  : shall be default real.
-
-The setting of compiler options specifying _real_ size can affect this
-function.
+the product of **x** and **y**. It is recommended that the processor
+compute the product in double precision, rather than in single precision
+then converted to double precision.
 
 ### **Arguments**
 
 - **x**
-  : Must be of default _real(kind=kind(0.0))_ type
+  : the multiplier, a _real_ value of default kind
 
 - **y**
-  : Must have the same type and kind parameters as **x**
+  : the multiplicand, a _real_ value of default kind.
+  **y** Must have the same type and kind parameters as **x**
+
+The setting of compiler options specifying the size of a default _real_
+can affect this function.
 
 ### **Returns**
 
-The return value is of type _real(kind=kind(0.0d0))_.
+The return value is doubleprecision (ie. _real(kind=kind(0.0d0))_).
+It should have the same value as **dble(x)\*dble(y)**.
 
 ### **Examples**
 
@@ -54,37 +53,54 @@ integer,parameter :: dp=kind(0.0d0)
 real :: x = 5.2
 real :: y = 2.3
 real(kind=dp) :: dd
+
+   ! basic usage
    dd = dprod(x,y)
-   print *, dd, x*y, kind(x), kind(dd), kind(dprod(x,y))
-   ! interesting comparisons
-   print *, 52*23
+   print *, 'compare dprod(xy)=',dd, &
+   & 'to x*y=',x*y, &
+   & 'to dble(x)*dble(y)=',dble(x)*dble(y)
+
+   ! elemental
+   print *, dprod( [2.3,3.4,4.5], 10.0 )
+   print *, dprod( [2.3,3.4,4.5], [9.8,7.6,5.4] )
+
+   ! other interesting comparisons
+   print *, 'integer multiplication of digits=',52*23
    print *, 52*23/100.0
    print *, 52*23/100.0d0
 
-   !! common extension is to take doubleprecision arguments
-   !! and return higher precision
+   !! A common extension is to take doubleprecision arguments
+   !! and return higher precision when available
    bigger: block
-   doubleprecision :: xx = 5.2d0
-   doubleprecision :: yy = 2.3d0
-   real(kind=real128) :: ddd
-   !ddd = dprod(xx,yy)
-   !print *, ddd, xx*yy, kind(xx), kind(ddd), kind(dprod(xx,yy))
+   doubleprecision :: xx = 5.2_dp
+   doubleprecision :: yy = 2.3_dp
+   print *, 'dprop==>',dprod(xx,yy)
+   print *, 'multipy==>',xx*yy
+   print *, 'using dble==>',dble(xx)*dble(yy)
+   print *, 'kind of arguments is',kind(xx)
+   print *, 'kind of result is',kind(dprod(xx,yy))
    endblock bigger
 
 end program demo_dprod
 ```
-
-Results:
-
+  Results:
+  (this can vary between programming environments):
 ```text
-   11.959999313354501 11.9599991 4 8 8
-        1196
-   11.9600000
-   11.960000000000001
+    compare dprod(xy)= 11.9599993133545 to x*y= 11.96000
+    to dble(x)*dble(y)= 11.9599993133545
+      22.9999995231628  34.0000009536743  45.0000000000000
+      22.5399999713898  25.8400004005432  24.3000004291534
+    integer multiplication of digits=        1196
+      11.96000
+      11.9600000000000
+    dprop==>   11.9599999999999994848565165739273
+    multipy==>   11.9600000000000
+    using dble==>   11.9600000000000
+    kind of arguments is           8
+    kind of result is          16
 ```
-
 ### **Standard**
 
 FORTRAN 77 and later
 
- _fortran-lang intrinsic descriptions_
+ _fortran-lang intrinsic descriptions (license: MIT) \@urbanjost_

--- a/source/learn/intrinsics/_pages/DPROD.md
+++ b/source/learn/intrinsics/_pages/DPROD.md
@@ -87,4 +87,4 @@ Results:
 
 FORTRAN 77 and later
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/DSHIFTL.md
+++ b/source/learn/intrinsics/_pages/DSHIFTL.md
@@ -39,4 +39,4 @@ Fortran 2008 and later
 
 [**dshiftr**(3)](#dshiftr)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/DSHIFTR.md
+++ b/source/learn/intrinsics/_pages/DSHIFTR.md
@@ -39,4 +39,4 @@ Fortran 2008 and later
 
 [**dshiftl**(3)](#dshiftl)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/EOSHIFT.md
+++ b/source/learn/intrinsics/_pages/EOSHIFT.md
@@ -85,4 +85,4 @@ Results:
 
 Fortran 95 and later
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/EPSILON.md
+++ b/source/learn/intrinsics/_pages/EPSILON.md
@@ -76,7 +76,7 @@ contains
    ! calculate the epsilon value of a machine the hard way
    real(kind=dp) :: t
    real(kind=dp) :: my_dp_eps
-   
+
       ! starting with a value of 1, keep dividing the value
       ! by 2 until no change is detected. Note that with
       ! infinite precision this would be an infinite loop,
@@ -89,7 +89,7 @@ contains
          if (t <= 1.0d0) exit
       enddo SET_ST
       my_dp_eps = 2.0d0*my_dp_eps
-   
+
    end function my_dp_eps
 end program demo_epsilon
 ```
@@ -130,4 +130,4 @@ Fortran 95 and later
 [**spacing**(3)](#spacing),
 [**tiny**(3)](#tiny)
 
-###### fortran-lang intrinsic descriptions (license: MIT) @urbanjost
+ _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_

--- a/source/learn/intrinsics/_pages/EPSILON.md
+++ b/source/learn/intrinsics/_pages/EPSILON.md
@@ -130,4 +130,4 @@ Fortran 95 and later
 [**spacing**(3)](#spacing),
 [**tiny**(3)](#tiny)
 
- _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_
+ _fortran-lang intrinsic descriptions (license: MIT) \@urbanjost_

--- a/source/learn/intrinsics/_pages/ERF.md
+++ b/source/learn/intrinsics/_pages/ERF.md
@@ -58,4 +58,4 @@ Fortran 2008 and later
 
 - [Wikipedia:error function](https://en.wikipedia.org/wiki/Error_function)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/ERFC.md
+++ b/source/learn/intrinsics/_pages/ERFC.md
@@ -75,4 +75,4 @@ Fortran 2008 and later
 
 - [Wikipedia:error function](https://en.wikipedia.org/wiki/Error_function)
 
-###### fortran-lang intrinsic descriptions (license: MIT) @urbanjost
+ _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_

--- a/source/learn/intrinsics/_pages/ERFC.md
+++ b/source/learn/intrinsics/_pages/ERFC.md
@@ -75,4 +75,4 @@ Fortran 2008 and later
 
 - [Wikipedia:error function](https://en.wikipedia.org/wiki/Error_function)
 
- _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_
+ _fortran-lang intrinsic descriptions (license: MIT) \@urbanjost_

--- a/source/learn/intrinsics/_pages/ERFC_SCALED.md
+++ b/source/learn/intrinsics/_pages/ERFC_SCALED.md
@@ -52,4 +52,4 @@ Results:
 
 Fortran 2008 and later
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/EVENT_QUERY.md
+++ b/source/learn/intrinsics/_pages/EVENT_QUERY.md
@@ -54,4 +54,4 @@ end program demo_event_query
 
 TS 18508 or later
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/EXECUTE_COMMAND_LINE.md
+++ b/source/learn/intrinsics/_pages/EXECUTE_COMMAND_LINE.md
@@ -103,4 +103,4 @@ be terminated alongside.
 
 Fortran 2008 and later
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/EXP.md
+++ b/source/learn/intrinsics/_pages/EXP.md
@@ -96,4 +96,4 @@ FORTRAN 77 and later
 
 - Wikipedia:[Euler's formula](https://en.wikipedia.org/wiki/Euler%27s_formula)
 
- _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_
+ _fortran-lang intrinsic descriptions (license: MIT) \@urbanjost_

--- a/source/learn/intrinsics/_pages/EXP.md
+++ b/source/learn/intrinsics/_pages/EXP.md
@@ -96,4 +96,4 @@ FORTRAN 77 and later
 
 - Wikipedia:[Euler's formula](https://en.wikipedia.org/wiki/Euler%27s_formula)
 
-###### fortran-lang intrinsic descriptions (license: MIT) @urbanjost
+ _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_

--- a/source/learn/intrinsics/_pages/EXPONENT.md
+++ b/source/learn/intrinsics/_pages/EXPONENT.md
@@ -68,4 +68,4 @@ Fortran 95 and later
 [**spacing**(3)](#spacing),
 [**tiny**(3)](#tiny)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/EXTENDS_TYPE_OF.md
+++ b/source/learn/intrinsics/_pages/EXTENDS_TYPE_OF.md
@@ -43,4 +43,4 @@ is an extension of the dynamic type of **mold**.
 
 ### **Examples**
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/FINDLOC.md
+++ b/source/learn/intrinsics/_pages/FINDLOC.md
@@ -193,4 +193,4 @@ has the value \[2, 1, 0\] and
 has the value \[2, 1\]. This is independent of the declared lower
 bounds for **b**.
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/FLOOR.md
+++ b/source/learn/intrinsics/_pages/FLOOR.md
@@ -90,4 +90,4 @@ Fortran 95 and later
 [**int**(3)](#int),
 [**selected_int_kind**(3)](#selected_int_kind)
 
-###### fortran-lang intrinsic descriptions (license: MIT) @urbanjost
+ _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_

--- a/source/learn/intrinsics/_pages/FLOOR.md
+++ b/source/learn/intrinsics/_pages/FLOOR.md
@@ -90,4 +90,4 @@ Fortran 95 and later
 [**int**(3)](#int),
 [**selected_int_kind**(3)](#selected_int_kind)
 
- _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_
+ _fortran-lang intrinsic descriptions (license: MIT) \@urbanjost_

--- a/source/learn/intrinsics/_pages/FRACTION.md
+++ b/source/learn/intrinsics/_pages/FRACTION.md
@@ -67,4 +67,4 @@ Fortran 95 and later
 [**spacing**(3)](#spacing),
 [**tiny**(3)](#tiny)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/GAMMA.md
+++ b/source/learn/intrinsics/_pages/GAMMA.md
@@ -130,4 +130,4 @@ Logarithm of the Gamma function: [**log_gamma**(3)](#log_gamma)
 
 [Wikipedia: Gamma_function](https://en.wikipedia.org/wiki/Gamma_function)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/GET_COMMAND.md
+++ b/source/learn/intrinsics/_pages/GET_COMMAND.md
@@ -88,4 +88,4 @@ Fortran 2003 and later
 [**get_command_argument**(3)](#get_command_argument),
 [**command_argument_count**(3)](#command_argument_count)
 
- _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_
+ _fortran-lang intrinsic descriptions (license: MIT) \@urbanjost_

--- a/source/learn/intrinsics/_pages/GET_COMMAND.md
+++ b/source/learn/intrinsics/_pages/GET_COMMAND.md
@@ -88,4 +88,4 @@ Fortran 2003 and later
 [**get_command_argument**(3)](#get_command_argument),
 [**command_argument_count**(3)](#command_argument_count)
 
-###### fortran-lang intrinsic descriptions (license: MIT) @urbanjost
+ _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_

--- a/source/learn/intrinsics/_pages/GET_COMMAND_ARGUMENT.md
+++ b/source/learn/intrinsics/_pages/GET_COMMAND_ARGUMENT.md
@@ -130,4 +130,4 @@ Fortran 2003 and later
 [**get_command**(3)](#get_command),
 [**command_argument_count**(3)](#command_argument_count)
 
-###### fortran-lang intrinsic descriptions (license: MIT) @urbanjost
+ _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_

--- a/source/learn/intrinsics/_pages/GET_COMMAND_ARGUMENT.md
+++ b/source/learn/intrinsics/_pages/GET_COMMAND_ARGUMENT.md
@@ -130,4 +130,4 @@ Fortran 2003 and later
 [**get_command**(3)](#get_command),
 [**command_argument_count**(3)](#command_argument_count)
 
- _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_
+ _fortran-lang intrinsic descriptions (license: MIT) \@urbanjost_

--- a/source/learn/intrinsics/_pages/GET_ENVIRONMENT_VARIABLE.md
+++ b/source/learn/intrinsics/_pages/GET_ENVIRONMENT_VARIABLE.md
@@ -126,4 +126,4 @@ Typical Results:
 
 Fortran 2003 and later
 
- _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_
+ _fortran-lang intrinsic descriptions (license: MIT) \@urbanjost_

--- a/source/learn/intrinsics/_pages/GET_ENVIRONMENT_VARIABLE.md
+++ b/source/learn/intrinsics/_pages/GET_ENVIRONMENT_VARIABLE.md
@@ -126,4 +126,4 @@ Typical Results:
 
 Fortran 2003 and later
 
-###### fortran-lang intrinsic descriptions (license: MIT) @urbanjost
+ _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_

--- a/source/learn/intrinsics/_pages/HUGE.md
+++ b/source/learn/intrinsics/_pages/HUGE.md
@@ -109,4 +109,4 @@ Fortran 95 and later
 [**spacing**(3)](#spacing),
 [**tiny**(3)](#tiny)
 
- _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_
+ _fortran-lang intrinsic descriptions (license: MIT) \@urbanjost_

--- a/source/learn/intrinsics/_pages/HUGE.md
+++ b/source/learn/intrinsics/_pages/HUGE.md
@@ -109,4 +109,4 @@ Fortran 95 and later
 [**spacing**(3)](#spacing),
 [**tiny**(3)](#tiny)
 
-###### fortran-lang intrinsic descriptions (license: MIT) @urbanjost
+ _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_

--- a/source/learn/intrinsics/_pages/HYPOT.md
+++ b/source/learn/intrinsics/_pages/HYPOT.md
@@ -97,4 +97,4 @@ Results:
 
 Fortran 2008 and later
 
- _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_
+ _fortran-lang intrinsic descriptions (license: MIT) \@urbanjost_

--- a/source/learn/intrinsics/_pages/HYPOT.md
+++ b/source/learn/intrinsics/_pages/HYPOT.md
@@ -97,4 +97,4 @@ Results:
 
 Fortran 2008 and later
 
-###### fortran-lang intrinsic descriptions (license: MIT) @urbanjost
+ _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_

--- a/source/learn/intrinsics/_pages/IACHAR.md
+++ b/source/learn/intrinsics/_pages/IACHAR.md
@@ -92,4 +92,4 @@ of arguments, and search for certain arguments:
   [**len**(3)](#len),
   [**repeat**(3)](#repeat), [**trim**(3)](#trim)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/IALL.md
+++ b/source/learn/intrinsics/_pages/IALL.md
@@ -76,4 +76,4 @@ Fortran 2008 and later
 [**iparity**(3)](#iparity),
 [**iand**(3)](#iand)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/IAND.md
+++ b/source/learn/intrinsics/_pages/IAND.md
@@ -63,4 +63,4 @@ Fortran 95 and later
 [**ieor**(3)](#ieor),
 [**mvbits**(3)](#mvbits)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/IANY.md
+++ b/source/learn/intrinsics/_pages/IANY.md
@@ -73,4 +73,4 @@ Fortran 2008 and later
 [**iall**(3)](#iall),
 [**ior**(3)](#ior)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/IBCLR.md
+++ b/source/learn/intrinsics/_pages/IBCLR.md
@@ -46,4 +46,4 @@ Fortran 95 and later
 [**ieor**(3)](#ieor),
 [**mvbits**(3)](#mvbits)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/IBITS.md
+++ b/source/learn/intrinsics/_pages/IBITS.md
@@ -50,4 +50,4 @@ Fortran 95 and later
 [**ieor**(3)](#ieor),
 [**mvbits**(3)](#mvbits)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/IBSET.md
+++ b/source/learn/intrinsics/_pages/IBSET.md
@@ -46,4 +46,4 @@ Fortran 95 and later
 [**ieor**(3)](#ieor),
 [**mvbits**(3)](#mvbits)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/ICHAR.md
+++ b/source/learn/intrinsics/_pages/ICHAR.md
@@ -56,7 +56,7 @@ contains
 
    subroutine printme()
    character(len=1) :: letter
-   
+
       letter=char(i)
       select case(i)
       case (:31,127:)
@@ -64,7 +64,7 @@ contains
       case default
          write(*,'(1x,i0.3,1x,a,1x,i0)')i,letter,ichar(letter)
       end select
-   
+
    end subroutine printme
 
 end program demo_ichar
@@ -128,4 +128,4 @@ of arguments, and search for certain arguments:
   [**repeat**(3)](#repeat),
   [**trim**(3)](#trim)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/IEOR.md
+++ b/source/learn/intrinsics/_pages/IEOR.md
@@ -44,4 +44,4 @@ Fortran 95 and later
 [**ior**(3)](#ior),
 [**mvbits**(3)](#mvbits)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/IMAGE_INDEX.md
+++ b/source/learn/intrinsics/_pages/IMAGE_INDEX.md
@@ -51,4 +51,4 @@ Fortran 2008 and later
 [**this_image**(3)](#this_image),
 [**num_images**(3)](#num_images)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/INDEX.md
+++ b/source/learn/intrinsics/_pages/INDEX.md
@@ -88,4 +88,4 @@ of arguments, and search for certain arguments:
   [**len**(3)](#len),
   [**repeat**(3)](#repeat), [**trim**(3)](#trim)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/INT.md
+++ b/source/learn/intrinsics/_pages/INT.md
@@ -128,4 +128,4 @@ FORTRAN 77 and later
 [**ceiling**(3)](#ceiling),
 [**floor**(3)](#floor)
 
-###### fortran-lang intrinsic descriptions (license: MIT) @urbanjost
+ _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_

--- a/source/learn/intrinsics/_pages/INT.md
+++ b/source/learn/intrinsics/_pages/INT.md
@@ -128,4 +128,4 @@ FORTRAN 77 and later
 [**ceiling**(3)](#ceiling),
 [**floor**(3)](#floor)
 
- _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_
+ _fortran-lang intrinsic descriptions (license: MIT) \@urbanjost_

--- a/source/learn/intrinsics/_pages/IOR.md
+++ b/source/learn/intrinsics/_pages/IOR.md
@@ -69,4 +69,4 @@ Fortran 95 and later
 [**ieor**(3)](#ieor),
 [**mvbits**(3)](#mvbits)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/IPARITY.md
+++ b/source/learn/intrinsics/_pages/IPARITY.md
@@ -72,4 +72,4 @@ Fortran 2008 and later
 [**ieor**(3)](#ieor),
 [**parity**(3)](#parity)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/ISHFT.md
+++ b/source/learn/intrinsics/_pages/ISHFT.md
@@ -40,4 +40,4 @@ Fortran 95 and later
 
 [**ishftc**(3)](#ishftc)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/ISHFTC.md
+++ b/source/learn/intrinsics/_pages/ISHFTC.md
@@ -44,4 +44,4 @@ Fortran 95 and later
 
 [**ishft**(3)](#ishft)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/IS_CONTIGUOUS.md
+++ b/source/learn/intrinsics/_pages/IS_CONTIGUOUS.md
@@ -116,4 +116,4 @@ Results:
 
 Fortran 2008 and later
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/IS_IOSTAT_END.md
+++ b/source/learn/intrinsics/_pages/IS_IOSTAT_END.md
@@ -61,4 +61,4 @@ end program demo_iostat
 
 Fortran 2003 and later
 
- _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_
+ _fortran-lang intrinsic descriptions (license: MIT) \@urbanjost_

--- a/source/learn/intrinsics/_pages/IS_IOSTAT_END.md
+++ b/source/learn/intrinsics/_pages/IS_IOSTAT_END.md
@@ -61,4 +61,4 @@ end program demo_iostat
 
 Fortran 2003 and later
 
-###### fortran-lang intrinsic descriptions (license: MIT) @urbanjost
+ _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_

--- a/source/learn/intrinsics/_pages/IS_IOSTAT_EOR.md
+++ b/source/learn/intrinsics/_pages/IS_IOSTAT_EOR.md
@@ -49,4 +49,4 @@ end program demo_is_iostat_eor
 
 Fortran 2003 and later
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/KIND.md
+++ b/source/learn/intrinsics/_pages/KIND.md
@@ -51,4 +51,4 @@ Results:
 
 Fortran 95 and later
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/LBOUND.md
+++ b/source/learn/intrinsics/_pages/LBOUND.md
@@ -117,4 +117,4 @@ Fortran 95 and later, with KIND argument - Fortran 2003 and later
 [**ubound**(3)](#ubound),
 [**co_lbound**(3)](#co_lbound)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/LEADZ.md
+++ b/source/learn/intrinsics/_pages/LEADZ.md
@@ -129,4 +129,4 @@ Fortran 2008 and later
 [**poppar**(3)](#poppar),
 [**trailz**(3)](#trailz)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/LEN.md
+++ b/source/learn/intrinsics/_pages/LEN.md
@@ -132,4 +132,4 @@ of arguments, and search for certain arguments:
   [**repeat**(3)](#repeat),
   [**trim**(3)](#trim)
 
- _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_
+ _fortran-lang intrinsic descriptions (license: MIT) \@urbanjost_

--- a/source/learn/intrinsics/_pages/LEN.md
+++ b/source/learn/intrinsics/_pages/LEN.md
@@ -132,4 +132,4 @@ of arguments, and search for certain arguments:
   [**repeat**(3)](#repeat),
   [**trim**(3)](#trim)
 
-###### fortran-lang intrinsic descriptions (license: MIT) @urbanjost
+ _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_

--- a/source/learn/intrinsics/_pages/LEN_TRIM.md
+++ b/source/learn/intrinsics/_pages/LEN_TRIM.md
@@ -91,4 +91,4 @@ of arguments, and search for certain arguments:
   [**len**(3)](#len),
   [**trim**(3)](#trim)
 
- _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_
+ _fortran-lang intrinsic descriptions (license: MIT) \@urbanjost_

--- a/source/learn/intrinsics/_pages/LEN_TRIM.md
+++ b/source/learn/intrinsics/_pages/LEN_TRIM.md
@@ -91,4 +91,4 @@ of arguments, and search for certain arguments:
   [**len**(3)](#len),
   [**trim**(3)](#trim)
 
-###### fortran-lang intrinsic descriptions (license: MIT) @urbanjost
+ _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_

--- a/source/learn/intrinsics/_pages/LGE.md
+++ b/source/learn/intrinsics/_pages/LGE.md
@@ -2,27 +2,29 @@
 
 ### **Name**
 
-**lge**(3) - \[CHARACTER:COMPARE\] Lexical greater than or equal
+**lge**(3) - \[CHARACTER:COMPARE\] ASCII Lexical greater than or equal
 
 ### **Syntax**
 
 ```fortran
-result = lge(string_a, string_b)
-```
+   elemental logical function lge(string_a, string_b)
 
+    character(len=*),intent(in) :: string_a
+    character(len=*),intent(in) :: string_b
+```
 ### **Description**
 
-Determines whether one string is lexically greater than or equal to
-another string, where the two strings are interpreted as containing
-ASCII character codes. If the String **a** and String **b** are not the same
-length, the shorter is compared as if spaces were appended to it to form
-a value that has the same length as the longer.
+  Determines whether one string is lexically greater than or equal to
+  another string, where the two strings are interpreted as containing
+  ASCII character codes. If the String **a** and String **b** are not
+  the same length, the shorter is compared as if spaces were appended
+  to it to form a value that has the same length as the longer.
 
-In general, the lexical comparison intrinsics **lge**(3), **lgt**(3), **lle**(3), and **llt**(3)
-differ from the corresponding intrinsic operators .ge., .gt., .le., and
-.lt., in that the latter use the processor's character ordering (which
-is not ASCII on some targets), whereas the former always use the ASCII
-ordering.
+  The lexical comparison intrinsics **lge**(3), **lgt**(3), **lle**(3),
+  and **llt**(3) differ from the corresponding intrinsic operators
+  _.ge., .gt., .le., and .lt._, in that the latter use the processor's
+  character ordering (which is not ASCII on some targets), whereas the
+  former always use the ASCII ordering.
 
 ### **Arguments**
 
@@ -34,16 +36,53 @@ ordering.
 
 ### **Returns**
 
-Returns .true. if string_a \>= string_b, and .false. otherwise, based
-on the ASCII ordering.
+Returns _.true._ if string_a \>= string_b, and _.false._ otherwise,
+based on the ASCII ordering.
 
+If both input arguments are null strings, _.true._ is always returned.
+
+### **Examples**
+
+Sample program:
+
+```fortran
+program demo_lge
+implicit none
+integer :: i
+   write(*,'(*(a))')(char(i),i=32,126)  ! ASCII order
+   write(*,*) lge('abc','ABC')          ! [T] lowercase is > uppercase
+   write(*,*) lge('abc','abc  ')        ! [T] trailing spaces
+   ! If both strings are of zero length the result is true
+   write(*,*) lge('','')                ! [T]  
+   write(*,*) lge('','a')               ! [F] the null string is padded
+   write(*,*) lge('a','')               ! [T]  
+   write(*,*) lge('abc',['abc','123'])  ! [T T]  scalar and array
+   write(*,*) lge(['cba', '123'],'abc') ! [T F]  
+   write(*,*) lge(['abc','123'],['cba','123']) ! [F T]  both arrays
+end program demo_lge
+```
+  Results:
+```text
+    !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ
+    [\]^_`abcdefghijklmnopqrstuvwxyz{|}~
+    T
+    T
+    T
+    F
+    T
+    T T
+    T F
+    F T
+```
 ### **Standard**
 
 FORTRAN 77 and later
 
 ### **See Also**
 
-**\[\[lgt**(3), **\[\[lle**(3), **\[\[llt**(3)
+  [**lgt**(3)](#lgt),
+  [**lle**(3)](#lle),
+  [**llt**(3)](#llt)
 
 Functions that perform operations on character strings, return lengths
 of arguments, and search for certain arguments:
@@ -62,4 +101,4 @@ of arguments, and search for certain arguments:
   [**repeat**(3)](#repeat),
   [**trim**(3)](#trim)
 
- _fortran-lang intrinsic descriptions_
+ _fortran-lang intrinsic descriptions \@urbanjost_

--- a/source/learn/intrinsics/_pages/LGE.md
+++ b/source/learn/intrinsics/_pages/LGE.md
@@ -62,4 +62,4 @@ of arguments, and search for certain arguments:
   [**repeat**(3)](#repeat),
   [**trim**(3)](#trim)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/LGT.md
+++ b/source/learn/intrinsics/_pages/LGT.md
@@ -64,4 +64,4 @@ of arguments, and search for certain arguments:
   [**repeat**(3)](#repeat),
   [**trim**(3)](#trim)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/LGT.md
+++ b/source/learn/intrinsics/_pages/LGT.md
@@ -2,27 +2,28 @@
 
 ### **Name**
 
-**lgt**(3) - \[CHARACTER:COMPARE\] Lexical greater than
+**lgt**(3) - \[CHARACTER:COMPARE\] ASCII Lexical greater than
 
 ### **Syntax**
-
 ```fortran
-result = lgt(string_a, string_b)
-```
+   elemental logical function lgt(string_a, string_b)
 
+    character(len=*),intent(in) :: string_a
+    character(len=*),intent(in) :: string_b
+```
 ### **Description**
 
-Determines whether one string is lexically greater than another string,
-where the two strings are interpreted as containing ASCII character
-codes. If the String **a** and String **b** are not the same length, the shorter
-is compared as if spaces were appended to it to form a value that has
-the same length as the longer.
+  Determines whether one string is lexically greater than another string,
+  where the two strings are interpreted as containing ASCII character
+  codes. If the String **a** and String **b** are not the same length,
+  the shorter is compared as if spaces were appended to it to form a
+  value that has the same length as the longer.
 
-In general, the lexical comparison intrinsics LGE, LGT, LLE, and LLT
-differ from the corresponding intrinsic operators .ge., .gt., .le., and
-.lt., in that the latter use the processor's character ordering (which
-is not ASCII on some targets), whereas the former always use the ASCII
-ordering.
+  In general, the lexical comparison intrinsics **lge**, **lgt**, **lle**,
+  and **llt** differ from the corresponding intrinsic operators _.ge.,
+  .gt., .le., and .lt._, in that the latter use the processor's character
+  ordering (which is not ASCII on some targets), whereas the former
+  always use the ASCII ordering.
 
 ### **Arguments**
 
@@ -34,21 +35,56 @@ ordering.
 
 ### **Returns**
 
-Returns .true. if string_a \> string_b, and .false. otherwise, based
-on the ASCII ordering.
+  Returns _.true._ if string_a \> string_b, and _.false._ otherwise,
+  based on the ASCII ordering.
 
+  If both input arguments are null strings, _.false._ is always returned.
+
+### **Examples**
+
+Sample program:
+
+```fortran
+program demo_lgt
+implicit none
+integer :: i
+   write(*,'(*(a))')(char(i),i=32,126)  ! ASCII order
+   write(*,*) lgt('abc','ABC')          ! [T] lowercase is > uppercase
+   write(*,*) lgt('abc','abc  ')        ! [F] trailing spaces
+   ! If both strings are of zero length the result is false.
+   write(*,*) lgt('','')                ! [F]  
+   write(*,*) lgt('','a')               ! [F] the null string is padded
+   write(*,*) lgt('a','')               ! [T]  
+   write(*,*) lgt('abc',['abc','123'])  ! [F T]  scalar and array
+   write(*,*) lgt(['cba', '123'],'abc') ! [T F]  
+   write(*,*) lgt(['abc','123'],['cba','123']) ! [F F]  both arrays
+end program demo_lgt
+```
+  Results:
+```text
+    !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ
+    [\]^_`abcdefghijklmnopqrstuvwxyz{|}~
+    T
+    F
+    F
+    F
+    T
+    F T
+    T F
+    F F
+```
 ### **Standard**
 
 FORTRAN 77 and later
 
 ### **See Also**
 
-[**lge**(3)](#lge),
-[**lle**(3)](#lle),
-[**llt**(3)](#llt)
+ [**lge**(3)](#lge),
+ [**lle**(3)](#lle),
+ [**llt**(3)](#llt)
 
-Functions that perform operations on character strings, return lengths
-of arguments, and search for certain arguments:
+  Functions that perform operations on character strings, return lengths
+  of arguments, and search for certain arguments:
 
 - **Elemental:**
   [**adjustl**(3)](#adjustl),
@@ -64,4 +100,4 @@ of arguments, and search for certain arguments:
   [**repeat**(3)](#repeat),
   [**trim**(3)](#trim)
 
- _fortran-lang intrinsic descriptions_
+ _fortran-lang intrinsic descriptions \@urbanjost_

--- a/source/learn/intrinsics/_pages/LLE.md
+++ b/source/learn/intrinsics/_pages/LLE.md
@@ -2,33 +2,30 @@
 
 ### **Name**
 
-**lle**(3) - \[CHARACTER:COMPARE\] Lexical less than or equal
+**lle**(3) - \[CHARACTER:COMPARE\] ASCII Lexical less than or equal
 
 ### **Syntax**
 
 ```fortran
-result = lle(str_a, str_b)
+   elemental logical function lle(string_a, string_b)
 
-   character(len=*),intent(in) :: str_a, str_b
-
-      or
-
-   character(len=*),intent(in) :: str_a, str_b(*) logical :: result
+    character(len=*),intent(in) :: string_a
+    character(len=*),intent(in) :: string_b
 ```
-
 ### **Description**
 
-Determines whether one string is lexically less than or equal to another
-string, where the two strings are interpreted as containing ASCII
-character codes. if the **string_a** and **string_b** are not the same length,
-the shorter is compared as if spaces were appended to it to form a value
-that has the same length as the longer. Leading spaces are significant.
+  Determines whether one string is lexically less than or equal to
+  another string, where the two strings are interpreted as containing
+  ASCII character codes. if the **string_a** and **string_b** are not
+  the same length, the shorter is compared as if spaces were appended
+  to it to form a value that has the same length as the longer. Leading
+  spaces are significant.
 
-In general, the lexical comparison intrinsics LGE, LGT, LLE, and LLT
-differ from the corresponding intrinsic operators .ge., .gt., .le., and
-.lt., in that the latter use the processor's character ordering (which
-is not ASCII on some targets), whereas the former always use the ASCII
-ordering.
+  In general, the lexical comparison intrinsics **lge**, **lgt**, **lle**,
+  and **llt** differ from the corresponding intrinsic operators _.ge.,
+  .gt., .le., and .lt._, in that the latter use the processor's character
+  ordering (which is not ASCII on some targets), whereas the former
+  always use the ASCII ordering.
 
 ### **Arguments**
 
@@ -44,8 +41,10 @@ ordering.
 ### **Returns**
 
 - **result**
-  Returns **.true.** if **STR_A \<= STR_B**, and **.false.** otherwise, based on
+  Returns _.true._ if **STR_A \<= STR_B**, and _.false._ otherwise, based on
   the ASCII ordering.
+
+  If both input arguments are null strings, _.true._ is always returned.
 
 ### **Examples**
 
@@ -54,20 +53,19 @@ Sample program:
 ```fortran
 program demo_lle
 implicit none
-integer             :: i
+integer :: i
    write(*,'(*(a))')(char(i),i=32,126)
-     write(*,*) lle('abc','ABC')              ! F lowercase is > uppercase
-     write(*,*) lle('abc','abc  ')            ! T trailing spaces
-     ! If both strings are of zero length the result is true.
-     write(*,*) lle('','')                    ! T
-     write(*,*) lle('','a')                   ! T the null string is padded
-     write(*,*) lle('a','')                   ! F
-     write(*,*) lle('abc',['abc','123'])      ! [T,F] scalar and array
-     write(*,*) lle(['cba', '123'],'abc')     ! [F,T]
-     write(*,*) lle(['abc','123'],['cba','123']) ! [T,T] both arrays
+   write(*,*) lle('abc','ABC')          ! F lowercase is > uppercase
+   write(*,*) lle('abc','abc  ')        ! T trailing spaces
+   ! If both strings are of zero length the result is true.
+   write(*,*) lle('','')                ! T
+   write(*,*) lle('','a')               ! T the null string is padded
+   write(*,*) lle('a','')               ! F
+   write(*,*) lle('abc',['abc','123'])  ! [T,F] scalar and array
+   write(*,*) lle(['cba', '123'],'abc') ! [F,T]
+   write(*,*) lle(['abc','123'],['cba','123']) ! [T,T] both arrays
 end program demo_lle
 ```
-
 Results:
 
 ```text
@@ -89,9 +87,9 @@ FORTRAN 77 and later
 
 ### **See Also**
 
-[**lge**(3)](#lge),
-[**lgt**(3)](#lgt),
-[**llt**(3)](#llt)
+  [**lge**(3)](#lge),
+  [**lgt**(3)](#lgt),
+  [**llt**(3)](#llt)
 
 Functions that perform operations on character strings, return lengths
 of arguments, and search for certain arguments:
@@ -110,4 +108,4 @@ of arguments, and search for certain arguments:
   [**repeat**(3)](#repeat),
   [**trim**(3)](#trim)
 
- _fortran-lang intrinsic descriptions_
+ _fortran-lang intrinsic descriptions \@urbanjost_

--- a/source/learn/intrinsics/_pages/LLE.md
+++ b/source/learn/intrinsics/_pages/LLE.md
@@ -110,4 +110,4 @@ of arguments, and search for certain arguments:
   [**repeat**(3)](#repeat),
   [**trim**(3)](#trim)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/LLT.md
+++ b/source/learn/intrinsics/_pages/LLT.md
@@ -59,4 +59,4 @@ of arguments, and search for certain arguments:
   [**len**(3)](#len),
   [**repeat**(3)](#repeat), [**trim**(3)](#trim)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/LLT.md
+++ b/source/learn/intrinsics/_pages/LLT.md
@@ -2,27 +2,29 @@
 
 ### **Name**
 
-**llt**(3) - \[CHARACTER:COMPARE\] Lexical less than
+**llt**(3) - \[CHARACTER:COMPARE\] ASCII Lexical less than
 
 ### **Syntax**
 
 ```fortran
-result = llt(string_a, string_b)
-```
+   elemental logical function llt(string_a, string_b)
 
+    character(len=*),intent(in) :: string_a
+    character(len=*),intent(in) :: string_b
+```
 ### **Description**
 
-Determines whether one string is lexically less than another string,
-where the two strings are interpreted as containing ASCII character
-codes. If the **string_a** and **string_b** are not the same length, the shorter
-is compared as if spaces were appended to it to form a value that has
-the same length as the longer.
+  Determines whether one string is lexically less than another string,
+  where the two strings are interpreted as containing ASCII character
+  codes. If the **string_a** and **string_b** are not the same length,
+  the shorter is compared as if spaces were appended to it to form a
+  value that has the same length as the longer.
 
-In general, the lexical comparison intrinsics LGE, LGT, LLE, and LLT
-differ from the corresponding intrinsic operators .ge., .gt., .le., and
-.lt., in that the latter use the processor's character ordering (which
-is not ASCII on some targets), whereas the former always use the ASCII
-ordering.
+  In general, the lexical comparison intrinsics **lge**, **lgt**, **lle**,
+  and **llt** differ from the corresponding intrinsic operators _.ge.,
+  .gt., .le., and .lt._, in that the latter use the processor's character
+  ordering (which is not ASCII on some targets), whereas the former
+  always use the ASCII ordering.
 
 ### **Arguments**
 
@@ -34,18 +36,53 @@ ordering.
 
 ### **Returns**
 
-Returns .true. if string_a \<= string_b, and .false. otherwise, based
-on the ASCII ordering.
+  Returns _.true._ if string_a \<= string_b, and _.false._ otherwise,
+  based on the ASCII ordering.
 
+  If both input arguments are null strings, _.false._ is always returned.
+
+### **Examples**
+
+Sample program:
+
+```fortran
+program demo_llt
+implicit none
+integer :: i
+   write(*,'(*(a))')(char(i),i=32,126)  ! ASCII order
+   write(*,*) llt('abc','ABC')          ! [F] lowercase is > uppercase
+   write(*,*) llt('abc','abc  ')        ! [F] trailing spaces
+   ! If both strings are of zero length the result is false.
+   write(*,*) llt('','')                ! [F]  
+   write(*,*) llt('','a')               ! [T] the null string is padded
+   write(*,*) llt('a','')               ! [F]  
+   write(*,*) llt('abc',['abc','123'])  ! [F F]  scalar and array
+   write(*,*) llt(['cba', '123'],'abc') ! [F T]  
+   write(*,*) llt(['abc','123'],['cba','123']) ! [T F]  both arrays
+end program demo_llt
+```
+  Results:
+```text
+  > !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ
+  > [\]^_`abcdefghijklmnopqrstuvwxyz{|}~
+  > F
+  > F
+  > F
+  > T
+  > F
+  > F F
+  > F T
+  > T F
+```
 ### **Standard**
 
 FORTRAN 77 and later
 
 ### **See Also**
 
-[**lge**(3)](#lge),
-[**lgt**(3)](#lgt),
-[**lle**(3)](#lle))
+  [**lge**(3)](#lge),
+  [**lgt**(3)](#lgt),
+  [**lle**(3)](#lle))
 
 Functions that perform operations on character strings, return lengths
 of arguments, and search for certain arguments:
@@ -59,4 +96,4 @@ of arguments, and search for certain arguments:
   [**len**(3)](#len),
   [**repeat**(3)](#repeat), [**trim**(3)](#trim)
 
- _fortran-lang intrinsic descriptions_
+ _fortran-lang intrinsic descriptions \@urbanjost_

--- a/source/learn/intrinsics/_pages/LOG.md
+++ b/source/learn/intrinsics/_pages/LOG.md
@@ -52,4 +52,4 @@ Results:
 
 FORTRAN 77 and later
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/LOG10.md
+++ b/source/learn/intrinsics/_pages/LOG10.md
@@ -61,4 +61,4 @@ Results:
 
 FORTRAN 77 and later
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/LOGICAL.md
+++ b/source/learn/intrinsics/_pages/LOGICAL.md
@@ -70,4 +70,4 @@ Fortran 95 and later, related ISO_FORTRAN_ENV module - fortran 2009
 [**real**(3)](#real),
 [**cmplx**(3)](#cmplx)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/LOG_GAMMA.md
+++ b/source/learn/intrinsics/_pages/LOG_GAMMA.md
@@ -49,4 +49,4 @@ Fortran 2008 and later
 
 Gamma function: [**gamma**(3)](#gamma)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/MASKL.md
+++ b/source/learn/intrinsics/_pages/MASKL.md
@@ -99,4 +99,4 @@ Fortran 2008 and later
 
 [**maskr**(3)](#maskr)
 
-###### fortran-lang intrinsic descriptions (license: MIT) @urbanjost
+ _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_

--- a/source/learn/intrinsics/_pages/MASKL.md
+++ b/source/learn/intrinsics/_pages/MASKL.md
@@ -99,4 +99,4 @@ Fortran 2008 and later
 
 [**maskr**(3)](#maskr)
 
- _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_
+ _fortran-lang intrinsic descriptions (license: MIT) \@urbanjost_

--- a/source/learn/intrinsics/_pages/MASKR.md
+++ b/source/learn/intrinsics/_pages/MASKR.md
@@ -107,4 +107,4 @@ Fortran 2008 and later
 
 [**maskl**(3)](#maskl)
 
-###### fortran-lang intrinsic descriptions (license: MIT) @urbanjost
+ _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_

--- a/source/learn/intrinsics/_pages/MASKR.md
+++ b/source/learn/intrinsics/_pages/MASKR.md
@@ -107,4 +107,4 @@ Fortran 2008 and later
 
 [**maskl**(3)](#maskl)
 
- _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_
+ _fortran-lang intrinsic descriptions (license: MIT) \@urbanjost_

--- a/source/learn/intrinsics/_pages/MATMUL.md
+++ b/source/learn/intrinsics/_pages/MATMUL.md
@@ -36,4 +36,4 @@ result follow the usual type and kind promotion rules, as for the \* or
 
 Fortran 95 and later
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/MAX.md
+++ b/source/learn/intrinsics/_pages/MAX.md
@@ -119,4 +119,4 @@ FORTRAN 77 and later
 [**maxval**(3)](#maxval),
 [**min**(3)](#min)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/MAXEXPONENT.md
+++ b/source/learn/intrinsics/_pages/MAXEXPONENT.md
@@ -69,4 +69,4 @@ Fortran 95 and later
 [**spacing**(3)](#spacing),
 [**tiny**(3)](#tiny)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/MAXLOC.md
+++ b/source/learn/intrinsics/_pages/MAXLOC.md
@@ -104,4 +104,4 @@ Fortran 95 and later
 [**max**(3)](#max),
 [**maxval**(3)](#maxval)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/MAXVAL.md
+++ b/source/learn/intrinsics/_pages/MAXVAL.md
@@ -87,4 +87,4 @@ Fortran 95 and later
 [**max**(3)](#max),
 [**maxloc**(3)](#maxloc)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/MERGE.md
+++ b/source/learn/intrinsics/_pages/MERGE.md
@@ -158,4 +158,4 @@ Fortran 95 and later
 [**spread**(3)](#spread),
 [**unpack**(3)](#unpack)
 
- _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_
+ _fortran-lang intrinsic descriptions (license: MIT) \@urbanjost_

--- a/source/learn/intrinsics/_pages/MERGE.md
+++ b/source/learn/intrinsics/_pages/MERGE.md
@@ -158,4 +158,4 @@ Fortran 95 and later
 [**spread**(3)](#spread),
 [**unpack**(3)](#unpack)
 
-###### fortran-lang intrinsic descriptions (license: MIT) @urbanjost
+ _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_

--- a/source/learn/intrinsics/_pages/MERGE_BITS.md
+++ b/source/learn/intrinsics/_pages/MERGE_BITS.md
@@ -119,4 +119,4 @@ Results:
 
 Fortran 2008 and later
 
-###### fortran-lang intrinsic descriptions (license: MIT) @urbanjost
+ _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_

--- a/source/learn/intrinsics/_pages/MERGE_BITS.md
+++ b/source/learn/intrinsics/_pages/MERGE_BITS.md
@@ -119,4 +119,4 @@ Results:
 
 Fortran 2008 and later
 
- _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_
+ _fortran-lang intrinsic descriptions (license: MIT) \@urbanjost_

--- a/source/learn/intrinsics/_pages/MIN.md
+++ b/source/learn/intrinsics/_pages/MIN.md
@@ -54,4 +54,4 @@ FORTRAN 77 and later
 [**minloc**(3)](#minloc),
 [**minval**(3)](#minval)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/MINEXPONENT.md
+++ b/source/learn/intrinsics/_pages/MINEXPONENT.md
@@ -69,4 +69,4 @@ Fortran 95 and later
 [**spacing**(3)](#spacing),
 [**tiny**(3)](#tiny)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/MINLOC.md
+++ b/source/learn/intrinsics/_pages/MINLOC.md
@@ -92,4 +92,4 @@ Fortran 95 and later
 [**min**(3)](#min),
 [**minval**(3)](#minval)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/MINVAL.md
+++ b/source/learn/intrinsics/_pages/MINVAL.md
@@ -148,4 +148,4 @@ Fortran 95 and later
 [**min**(3)](#min),
 [**minloc**(3)](#minloc)
 
-###### fortran-lang intrinsic descriptions (license: MIT) @urbanjost
+ _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_

--- a/source/learn/intrinsics/_pages/MINVAL.md
+++ b/source/learn/intrinsics/_pages/MINVAL.md
@@ -148,4 +148,4 @@ Fortran 95 and later
 [**min**(3)](#min),
 [**minloc**(3)](#minloc)
 
- _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_
+ _fortran-lang intrinsic descriptions (license: MIT) \@urbanjost_

--- a/source/learn/intrinsics/_pages/MOD.md
+++ b/source/learn/intrinsics/_pages/MOD.md
@@ -79,4 +79,4 @@ FORTRAN 77 and later
 
 [**modulo**(3)](#modulo)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/MODULO.md
+++ b/source/learn/intrinsics/_pages/MODULO.md
@@ -73,4 +73,4 @@ Fortran 95 and later
 
 [**mod**(3)](#mod)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/MOVE_ALLOC.md
+++ b/source/learn/intrinsics/_pages/MOVE_ALLOC.md
@@ -73,4 +73,4 @@ Fortran 2003 and later
 
 [**allocated**(3)](#allocated)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/MVBITS.md
+++ b/source/learn/intrinsics/_pages/MVBITS.md
@@ -145,4 +145,4 @@ Fortran 95 and later
 [**ior**(3)](#ior),
 [**ieor**(3)](#ieor)
 
- _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_
+ _fortran-lang intrinsic descriptions (license: MIT) \@urbanjost_

--- a/source/learn/intrinsics/_pages/MVBITS.md
+++ b/source/learn/intrinsics/_pages/MVBITS.md
@@ -79,7 +79,7 @@ character(len=*),parameter :: fmt= '(g0,t30,a,t40,b32.32)'
 
     !! COPY PART OF A VALUE TO ITSELF
     ! can copy bit from a value to itself
-    call mvbits(intfrom,0,1,intfrom,31) 
+    call mvbits(intfrom,0,1,intfrom,31)
     write(*,bits)intfrom,intfrom
 
     !! MOVING BYTES AT A TIME
@@ -145,4 +145,4 @@ Fortran 95 and later
 [**ior**(3)](#ior),
 [**ieor**(3)](#ieor)
 
-###### fortran-lang intrinsic descriptions (license: MIT) @urbanjost
+ _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_

--- a/source/learn/intrinsics/_pages/NEAREST.md
+++ b/source/learn/intrinsics/_pages/NEAREST.md
@@ -84,4 +84,4 @@ Fortran 95 and later
 [**spacing**(3)](#spacing),
 [**tiny**(3)](#tiny)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/NEW_LINE.md
+++ b/source/learn/intrinsics/_pages/NEW_LINE.md
@@ -77,4 +77,4 @@ Results:
 
 Fortran 2003 and later
 
- _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_
+ _fortran-lang intrinsic descriptions (license: MIT) \@urbanjost_

--- a/source/learn/intrinsics/_pages/NEW_LINE.md
+++ b/source/learn/intrinsics/_pages/NEW_LINE.md
@@ -77,4 +77,4 @@ Results:
 
 Fortran 2003 and later
 
-###### fortran-lang intrinsic descriptions (license: MIT) @urbanjost
+ _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_

--- a/source/learn/intrinsics/_pages/NINT.md
+++ b/source/learn/intrinsics/_pages/NINT.md
@@ -124,4 +124,4 @@ FORTRAN 77 and later, with KIND argument - Fortran 90 and later
 [**ceiling**(3)](#ceiling),
 [**floor**(3)](#floor)
 
- _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_
+ _fortran-lang intrinsic descriptions (license: MIT) \@urbanjost_

--- a/source/learn/intrinsics/_pages/NINT.md
+++ b/source/learn/intrinsics/_pages/NINT.md
@@ -124,4 +124,4 @@ FORTRAN 77 and later, with KIND argument - Fortran 90 and later
 [**ceiling**(3)](#ceiling),
 [**floor**(3)](#floor)
 
-###### fortran-lang intrinsic descriptions (license: MIT) @urbanjost
+ _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_

--- a/source/learn/intrinsics/_pages/NORM2.md
+++ b/source/learn/intrinsics/_pages/NORM2.md
@@ -91,4 +91,4 @@ Fortran 2008 and later
 [**sum**(3)](#sum),
 [**hypot**(3)](#hypot)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/NOT.md
+++ b/source/learn/intrinsics/_pages/NOT.md
@@ -60,4 +60,4 @@ Fortran 95 and later
 
 [**ibclr**(3)](#ibclr)
 
- _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_
+ _fortran-lang intrinsic descriptions (license: MIT) \@urbanjost_

--- a/source/learn/intrinsics/_pages/NOT.md
+++ b/source/learn/intrinsics/_pages/NOT.md
@@ -60,4 +60,4 @@ Fortran 95 and later
 
 [**ibclr**(3)](#ibclr)
 
-###### fortran-lang intrinsic descriptions (license: MIT) @urbanjost
+ _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_

--- a/source/learn/intrinsics/_pages/NULL.md
+++ b/source/learn/intrinsics/_pages/NULL.md
@@ -119,4 +119,4 @@ Fortran 95 and later
 
 [**associated**(3)](#associated)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/NUM_IMAGES.md
+++ b/source/learn/intrinsics/_pages/NUM_IMAGES.md
@@ -64,4 +64,4 @@ Fortran 2008 and later. With DISTANCE or FAILED argument, TS 18508 or later
 [**this_image**(3)](#this_image),
 [**image_index**(3)](#this_index)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/OUT_OF_RANGE.md
+++ b/source/learn/intrinsics/_pages/OUT_OF_RANGE.md
@@ -20,15 +20,15 @@
    **mold**.
 
 ### **Arguments**
-   - **x**           
+   - **x**
      : a scalar of type _integer_ or _real_ to be tested for whether
      it can be stored in a variable of the type and kind of **mold**
 
-   - **mold**        
+   - **mold**
      : shall be an _integer_ or _real_ scalar. If it is a variable, it
      need not be defined, as only the type and kind are queried.
 
-   - **round** 
+   - **round**
      : flag whether to round the value of **xx** before validating it as
      an integer value like **mold**.
 
@@ -84,7 +84,7 @@ integer            :: i
 integer(kind=int8) :: i8, j8
 
     ! compilers are not required to produce an error on out of range.
-    ! here storing the default integers into 1-byte integers 
+    ! here storing the default integers into 1-byte integers
     ! incorrectly can have unexpected results
     do i=127,130
        i8=i
@@ -120,4 +120,4 @@ Results:
 
    FORTRAN 2018 and later
 
-###### fortran-lang intrinsic descriptions (license: MIT) @urbanjost
+ _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_

--- a/source/learn/intrinsics/_pages/OUT_OF_RANGE.md
+++ b/source/learn/intrinsics/_pages/OUT_OF_RANGE.md
@@ -120,4 +120,4 @@ Results:
 
    FORTRAN 2018 and later
 
- _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_
+ _fortran-lang intrinsic descriptions (license: MIT) \@urbanjost_

--- a/source/learn/intrinsics/_pages/PACK.md
+++ b/source/learn/intrinsics/_pages/PACK.md
@@ -113,4 +113,4 @@ Fortran 95 and later
 [**spread**(3)](#spread),
 [**unpack**(3)](#unpack)
 
-###### fortran-lang intrinsic descriptions (license: MIT) @urbanjost
+ _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_

--- a/source/learn/intrinsics/_pages/PACK.md
+++ b/source/learn/intrinsics/_pages/PACK.md
@@ -113,4 +113,4 @@ Fortran 95 and later
 [**spread**(3)](#spread),
 [**unpack**(3)](#unpack)
 
- _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_
+ _fortran-lang intrinsic descriptions (license: MIT) \@urbanjost_

--- a/source/learn/intrinsics/_pages/PARITY.md
+++ b/source/learn/intrinsics/_pages/PARITY.md
@@ -65,4 +65,4 @@ Results:
 
 Fortran 2008 and later
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/POPCNT.md
+++ b/source/learn/intrinsics/_pages/POPCNT.md
@@ -63,4 +63,4 @@ Fortran 2008 and later
 [**leadz**(3)](#leadz),
 [**trailz**(3)](#trailz)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/POPPAR.md
+++ b/source/learn/intrinsics/_pages/POPPAR.md
@@ -64,4 +64,4 @@ Fortran 2008 and later
 [**leadz**(3)](#leadz),
 [**trailz**(3)](#trailz)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/PRECISION.md
+++ b/source/learn/intrinsics/_pages/PRECISION.md
@@ -69,4 +69,4 @@ Fortran 95 and later
 [**spacing**(3)](#spacing),
 [**tiny**(3)](#tiny)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/PRESENT.md
+++ b/source/learn/intrinsics/_pages/PRESENT.md
@@ -62,4 +62,4 @@ Results:
 
 Fortran 95 and later
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/PRODUCT.md
+++ b/source/learn/intrinsics/_pages/PRODUCT.md
@@ -133,14 +133,14 @@ contains
 
    subroutine print_matrix_int(title,arr)
    implicit none
-   
+
    !@(#) print small 2d integer arrays in row-column format
-   
+
    character(len=*),intent(in)  :: title
    integer,intent(in)           :: arr(:,:)
    integer                      :: i
    character(len=:),allocatable :: biggest
-   
+
       print all
       print all, trim(title),':(',shape(arr),')'  ! print title
       biggest='           '  ! make buffer to write integer into
@@ -153,7 +153,7 @@ contains
          write(*,fmt=biggest,advance='no')arr(i,:)
          write(*,'(" ]")')
       enddo
-   
+
    end subroutine print_matrix_int
 
 end program demo_product
@@ -231,4 +231,4 @@ Fortran 95 and later
 [**sum**(3)](#sum), note that an element by element multiplication is done
 directly using the star character.
 
-###### fortran-lang intrinsic descriptions (license: MIT) @urbanjost
+ _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_

--- a/source/learn/intrinsics/_pages/PRODUCT.md
+++ b/source/learn/intrinsics/_pages/PRODUCT.md
@@ -231,4 +231,4 @@ Fortran 95 and later
 [**sum**(3)](#sum), note that an element by element multiplication is done
 directly using the star character.
 
- _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_
+ _fortran-lang intrinsic descriptions (license: MIT) \@urbanjost_

--- a/source/learn/intrinsics/_pages/RADIX.md
+++ b/source/learn/intrinsics/_pages/RADIX.md
@@ -67,4 +67,4 @@ Fortran 95 and later
 [**spacing**(3)](#spacing),
 [**tiny**(3)](#tiny)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/RANDOM_NUMBER.md
+++ b/source/learn/intrinsics/_pages/RANDOM_NUMBER.md
@@ -90,4 +90,4 @@ Fortran 95 and later
 
 [**random_seed**(3)](#random_seed)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/RANDOM_SEED.md
+++ b/source/learn/intrinsics/_pages/RANDOM_SEED.md
@@ -68,4 +68,4 @@ Fortran 95 and later
 
 [**random_number**(3)](#random_number)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/RANGE.md
+++ b/source/learn/intrinsics/_pages/RANGE.md
@@ -75,4 +75,4 @@ Fortran 95 and later
 [**spacing**(3)](#spacing),
 [**tiny**(3)](#tiny)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/RANK.md
+++ b/source/learn/intrinsics/_pages/RANK.md
@@ -48,4 +48,4 @@ Results:
 
 TS 29113
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/REAL.md
+++ b/source/learn/intrinsics/_pages/REAL.md
@@ -73,4 +73,4 @@ FORTRAN 77 and later
 [**dble**(3)](#dble),
 [**float**(3)](#float)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/REDUCE.md
+++ b/source/learn/intrinsics/_pages/REDUCE.md
@@ -186,4 +186,4 @@ one relative to the input array.
 
    Fortran 2018
 
- _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_
+ _fortran-lang intrinsic descriptions (license: MIT) \@urbanjost_

--- a/source/learn/intrinsics/_pages/REDUCE.md
+++ b/source/learn/intrinsics/_pages/REDUCE.md
@@ -186,4 +186,4 @@ one relative to the input array.
 
    Fortran 2018
 
-###### fortran-lang intrinsic descriptions (license: MIT) @urbanjost
+ _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_

--- a/source/learn/intrinsics/_pages/REPEAT.md
+++ b/source/learn/intrinsics/_pages/REPEAT.md
@@ -80,4 +80,4 @@ Functions that perform operations on character strings:
   [**repeat**(3)](#repeat),
   [**trim**(3)](#trim)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/RESHAPE.md
+++ b/source/learn/intrinsics/_pages/RESHAPE.md
@@ -76,4 +76,4 @@ Fortran 95 and later
 
 [**shape**(3)](#shape)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/RRSPACING.md
+++ b/source/learn/intrinsics/_pages/RRSPACING.md
@@ -47,4 +47,4 @@ Fortran 95 and later
 [**spacing**(3)](#spacing),
 [**tiny**(3)](#tiny)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/SAME_TYPE_AS.md
+++ b/source/learn/intrinsics/_pages/SAME_TYPE_AS.md
@@ -37,4 +37,4 @@ Fortran 2003 and later
 
 [**extends_type_of**(3)](#extends_type_of)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/SCALE.md
+++ b/source/learn/intrinsics/_pages/SCALE.md
@@ -71,4 +71,4 @@ Fortran 95 and later
 [**spacing**(3)](#spacing),
 [**tiny**(3)](#tiny)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/SCAN.md
+++ b/source/learn/intrinsics/_pages/SCAN.md
@@ -78,4 +78,4 @@ of arguments, and search for certain arguments:
   [**len**(3)](#len),
   [**repeat**(3)](#repeat), [**trim**(3)](#trim)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/SELECTED_CHAR_KIND.md
+++ b/source/learn/intrinsics/_pages/SELECTED_CHAR_KIND.md
@@ -60,4 +60,4 @@ Results:
 
 Fortran 2003 and later
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/SELECTED_INT_KIND.md
+++ b/source/learn/intrinsics/_pages/SELECTED_INT_KIND.md
@@ -63,4 +63,4 @@ Fortran 95 and later
 [**ceiling**(3)](#ceiling),
 [**floor**(3)](#floor)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/SELECTED_REAL_KIND.md
+++ b/source/learn/intrinsics/_pages/SELECTED_REAL_KIND.md
@@ -41,23 +41,23 @@ than one real data type meet the criteria, the kind of the data type
 with the smallest decimal precision is returned. If no real data type
 matches the criteria, the result is
 
-  - **-1** 
+  - **-1**
   : if the processor does not support a real data type with a
     precision greater than or equal to **p**, but the **r** and **radix**
     requirements can be fulfilled
 
-  - **-2** 
+  - **-2**
   : if the processor does not support a real type with an
     exponent range greater than or equal to **r**, but **p** and **radix** are
     fulfillable
 
-  - **-3** 
+  - **-3**
   : if **radix** but not **p** and **r** requirements are fulfillable
 
-  - **-4** 
+  - **-4**
   : if **radix** and either **p** or **r** requirements are fulfillable
 
-  - **-5** 
+  - **-5**
   : if there is no real type with the given **radix**
 
 ### **Examples**
@@ -98,4 +98,4 @@ Fortran 95 and later; with RADIX - Fortran 2008 and later
 [**range**(3)](#range),
 [**radix**(3)](#radix)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/SET_EXPONENT.md
+++ b/source/learn/intrinsics/_pages/SET_EXPONENT.md
@@ -70,4 +70,4 @@ Fortran 95 and later
 [**spacing**(3)](#spacing),
 [**tiny**(3)](#tiny)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/SHAPE.md
+++ b/source/learn/intrinsics/_pages/SHAPE.md
@@ -68,4 +68,4 @@ Fortran 95 and later; with KIND argument Fortran 2003 and later
 [**reshape**(3)](#reshape),
 [**size**(3)](#size)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/SHIFTA.md
+++ b/source/learn/intrinsics/_pages/SHIFTA.md
@@ -40,4 +40,4 @@ Fortran 2008 and later
 [**shiftl**(3)](#shiftl),
 [**shiftr**(3)](#shiftr)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/SHIFTL.md
+++ b/source/learn/intrinsics/_pages/SHIFTL.md
@@ -38,4 +38,4 @@ Fortran 2008 and later
 [**shifta**(3)](#shifta),
 [**shiftr**(3)](#shiftr)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/SHIFTR.md
+++ b/source/learn/intrinsics/_pages/SHIFTR.md
@@ -38,4 +38,4 @@ Fortran 2008 and later
 [**shifta**(3)](#shifta),
 [**shiftl**(3)](#shiftl)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/SIGN.md
+++ b/source/learn/intrinsics/_pages/SIGN.md
@@ -78,4 +78,4 @@ Results:
 
 FORTRAN 77 and later
 
- _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_
+ _fortran-lang intrinsic descriptions (license: MIT) \@urbanjost_

--- a/source/learn/intrinsics/_pages/SIGN.md
+++ b/source/learn/intrinsics/_pages/SIGN.md
@@ -78,4 +78,4 @@ Results:
 
 FORTRAN 77 and later
 
-###### fortran-lang intrinsic descriptions (license: MIT)
+ _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_

--- a/source/learn/intrinsics/_pages/SIN.md
+++ b/source/learn/intrinsics/_pages/SIN.md
@@ -133,4 +133,4 @@ FORTRAN 77 and later
 [**cos**(3)](#cos),
 [**tan**(3)](#tan)
 
- _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_
+ _fortran-lang intrinsic descriptions (license: MIT) \@urbanjost_

--- a/source/learn/intrinsics/_pages/SIN.md
+++ b/source/learn/intrinsics/_pages/SIN.md
@@ -133,4 +133,4 @@ FORTRAN 77 and later
 [**cos**(3)](#cos),
 [**tan**(3)](#tan)
 
-###### fortran-lang intrinsic descriptions (license: MIT) @urbanjost
+ _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_

--- a/source/learn/intrinsics/_pages/SINH.md
+++ b/source/learn/intrinsics/_pages/SINH.md
@@ -93,4 +93,4 @@ Fortran 95 and later, for a complex argument Fortran 2008 or later
 
 [**asinh**(3)](#asinh)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/SIZE.md
+++ b/source/learn/intrinsics/_pages/SIZE.md
@@ -189,4 +189,4 @@ Fortran 95 and later, with **kind** argument - Fortran 2003 and later
 [**shape**(3)](#shape),
 [__reshape__(3)])(RESHAPE)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/SPACING.md
+++ b/source/learn/intrinsics/_pages/SPACING.md
@@ -68,4 +68,4 @@ Fortran 95 and later
 [**set_exponent**(3)](#set_exponent),
 [**tiny**(3)](#tiny)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/SPREAD.md
+++ b/source/learn/intrinsics/_pages/SPREAD.md
@@ -125,4 +125,4 @@ Fortran 95 and later
 [**pack**(3)](#pack),
 [**unpack**(3)](#unpack)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/SQRT.md
+++ b/source/learn/intrinsics/_pages/SQRT.md
@@ -90,4 +90,4 @@ Results:
 
 FORTRAN 77 and later
 
-###### fortran-lang intrinsic descriptions (license: MIT) @urbanjost
+ _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_

--- a/source/learn/intrinsics/_pages/SQRT.md
+++ b/source/learn/intrinsics/_pages/SQRT.md
@@ -90,4 +90,4 @@ Results:
 
 FORTRAN 77 and later
 
- _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_
+ _fortran-lang intrinsic descriptions (license: MIT) \@urbanjost_

--- a/source/learn/intrinsics/_pages/STORAGE_SIZE.md
+++ b/source/learn/intrinsics/_pages/STORAGE_SIZE.md
@@ -62,4 +62,4 @@ Fortran 2008 and later
 
 [**c_sizeof**(3)](#c_sizeof)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/SUM.md
+++ b/source/learn/intrinsics/_pages/SUM.md
@@ -88,4 +88,4 @@ Fortran 95 and later
 
 intrinsics
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/SYSTEM_CLOCK.md
+++ b/source/learn/intrinsics/_pages/SYSTEM_CLOCK.md
@@ -106,4 +106,4 @@ Fortran 95 and later
 [**date_and_time**(3)](#date_and_time),
 [**cpu_time**(3)](#cpu_time)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/TAN.md
+++ b/source/learn/intrinsics/_pages/TAN.md
@@ -53,4 +53,4 @@ FORTRAN 77 and later. For a complex argument, Fortran 2008 or later.
 [**cos**(3)](#cos),
 [**sin**(3)](#sin)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/TANH.md
+++ b/source/learn/intrinsics/_pages/TANH.md
@@ -59,4 +59,4 @@ FORTRAN 77 and later, for a complex argument Fortran 2008 or later
 
 [**atanh**(3)](#atanh)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/THIS_IMAGE.md
+++ b/source/learn/intrinsics/_pages/THIS_IMAGE.md
@@ -7,12 +7,12 @@
 ### **Syntax**
 
 ```fortran
-result = this_image() 
+result = this_image()
 ```
 or
 ```
 ```fortran
-result = this_image(distance) 
+result = this_image(distance)
 ```
 or
 ```fortran
@@ -85,5 +85,5 @@ or later
 [**num\_images**(3)](#num_images),
 [**image\_index**(3)](#image_index)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_
 ```

--- a/source/learn/intrinsics/_pages/TINY.md
+++ b/source/learn/intrinsics/_pages/TINY.md
@@ -71,4 +71,4 @@ Fortran 95 and later
 [**set_exponent**(3)](#set_exponent),
 [**spacing**(3)](#spacing)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/TRAILZ.md
+++ b/source/learn/intrinsics/_pages/TRAILZ.md
@@ -114,4 +114,4 @@ Fortran 2008 and later
 [**poppar**(3)](#poppar),
 [**leadz**(3)](#leadz)
 
-###### fortran-lang intrinsic descriptions (license: MIT) @urbanjost
+ _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_

--- a/source/learn/intrinsics/_pages/TRAILZ.md
+++ b/source/learn/intrinsics/_pages/TRAILZ.md
@@ -114,4 +114,4 @@ Fortran 2008 and later
 [**poppar**(3)](#poppar),
 [**leadz**(3)](#leadz)
 
- _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_
+ _fortran-lang intrinsic descriptions (license: MIT) \@urbanjost_

--- a/source/learn/intrinsics/_pages/TRANSFER.md
+++ b/source/learn/intrinsics/_pages/TRANSFER.md
@@ -107,4 +107,4 @@ oblivious to the benefits of EQUIVALENCEs when used sparingly.
 
 Fortran 90 and later
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/TRANSPOSE.md
+++ b/source/learn/intrinsics/_pages/TRANSPOSE.md
@@ -85,4 +85,4 @@ Results:
 
 Fortran 95 and later
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/TRIM.md
+++ b/source/learn/intrinsics/_pages/TRIM.md
@@ -74,4 +74,4 @@ of arguments, and search for certain arguments:
   [**repeat**(3)](#repeat),
   [**trim**(3)](#trim)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/UBOUND.md
+++ b/source/learn/intrinsics/_pages/UBOUND.md
@@ -119,4 +119,4 @@ and later
 [**co_ubound**(3)](#co_ubound),
 [__co\_lbound__(3)(co_lbound)]
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/UNPACK.md
+++ b/source/learn/intrinsics/_pages/UNPACK.md
@@ -31,7 +31,7 @@ values from **vector**.
   as many elements as **mask** has **.true.** values.
 
 - **mask**
-  : Shall be an array of type _logical_. 
+  : Shall be an array of type _logical_.
 
 - **field**
   : Shall be of the same type and type parameters as **vector** and
@@ -57,26 +57,26 @@ of **mask** replaced by values from **vector** in array element order.
 ### **Examples**
 Particular values may be "scattered" to particular positions in an array by using
 ```text
-                       1 0 0        
-    If M is the array  0 1 0 
-                       0 0 1  
+                       1 0 0
+    If M is the array  0 1 0
+                       0 0 1
 
     V is the array [1, 2, 3],
-		               . T .
+                               . T .
     and Q is the logical mask  T . .
-  	                       . . T
-    where "T" represents true and "." represents false, then the result of 
+                               . . T
+    where "T" represents true and "." represents false, then the result of
 
     UNPACK (V, MASK = Q, FIELD = M) has the value
-                                       
-      1 2 0 
-      1 1 0  
-      0 0 3 
+
+      1 2 0
+      1 1 0
+      0 0 3
 
     and the result of UNPACK (V, MASK = Q, FIELD = 0) has the value
 
       0 2 0
-      1 0 0 
+      1 0 0
       0 0 3
 ```
 
@@ -115,4 +115,4 @@ Fortran 95 and later
 [**spread**(3)](#spread),
 [**unpack**(3)](#unpack)
 
-###### fortran-lang intrinsic descriptions
+ _fortran-lang intrinsic descriptions_

--- a/source/learn/intrinsics/_pages/VERIFY.md
+++ b/source/learn/intrinsics/_pages/VERIFY.md
@@ -271,4 +271,4 @@ of arguments, and search for certain arguments:
   [**repeat**(3)](#repeat),
   [**trim**(3)](#trim)
 
- _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_
+ _fortran-lang intrinsic descriptions (license: MIT) \@urbanjost_

--- a/source/learn/intrinsics/_pages/VERIFY.md
+++ b/source/learn/intrinsics/_pages/VERIFY.md
@@ -271,4 +271,4 @@ of arguments, and search for certain arguments:
   [**repeat**(3)](#repeat),
   [**trim**(3)](#trim)
 
-###### fortran-lang intrinsic descriptions (license: MIT) @urbanjost
+ _fortran-lang intrinsic descriptions (license: MIT) @urbanjost_


### PR DESCRIPTION
new markdown rendering treats level six headers differently, making the footnote appear too large.  Just changing it to italic text instead, as this no longer creates a small font as-is.