### PR TITLE
Add/Update initial Russian translation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # You can set these variables from the command line, and also
 # from the environment .
 
-LANGUAGES     ?= en cs de zh_CN es fr nl ja pt
+LANGUAGES     ?= en cs de es fr ja nl pt ru zh_CN
 SPHINXINTL    ?= sphinx-intl
 SPHINXOPTS    ?=
 SPHINXBUILD   ?= sphinx-build

--- a/locale/ru/LC_MESSAGES/index.po
+++ b/locale/ru/LC_MESSAGES/index.po
@@ -4,18 +4,22 @@
 # website package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2022.
 #
-#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: Fortran-lang.org website \n"
+"Project-Id-Version: Fortran-lang.org website\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-09-29 16:02+0200\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
+"PO-Revision-Date: 2022-09-29 21:37+0000\n"
+"Last-Translator: Sergey Torokhov <torokhov-s-a@yandex.ru>\n"
+"Language-Team: Russian <https://hosted.weblate.org/projects/fortran-lang/"
+"webpage/ru/>\n"
+"Language: ru\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"X-Generator: Weblate 4.14.1\n"
 "Generated-By: Babel 2.10.3\n"
 
 #: ../../source/community.md:10
@@ -1713,18 +1717,19 @@ msgstr ""
 #: ../../source/index.md:8
 msgid "Fortran <br> High-performance parallel programming language"
 msgstr ""
+"Fortran <br> Высокопроизводительный язык <br> параллельного программирования"
 
 #: ../../source/index.md:12
 msgid "{bdg-link-primary}`Get started <learn/>`"
-msgstr ""
+msgstr "{bdg-link-primary}`Начать обучение <learn/>`"
 
 #: ../../source/index.md:16
 msgid "Features"
-msgstr ""
+msgstr "Особенности"
 
 #: ../../source/index.md:20
 msgid "High performance"
-msgstr ""
+msgstr "Высокая производительность"
 
 #: ../../source/index.md:23
 msgid ""
@@ -1732,10 +1737,15 @@ msgid ""
 "applications in science and engineering. Mature and battle-tested compilers "
 "and libraries allow you to write code that runs close to the metal, fast."
 msgstr ""
+"Fortran (Фортран) изначально был разработан для приложений с интенсивными "
+"вычислениями в области науки и проектирования. Тщательно разработанные и "
+"протестированные оптимизирующие компиляторы и библиотеки позволяют писать "
+"программы, которые исполняются так быстро, насколько это возможно на "
+"используемом оборудовании."
 
 #: ../../source/index.md:26
 msgid "Statically and strongly typed"
-msgstr ""
+msgstr "Статическая и сильная типизация"
 
 #: ../../source/index.md:29
 msgid ""
@@ -1743,10 +1753,13 @@ msgid ""
 "many programming errors early on for you. This also allows the compiler to "
 "generate efficient binary code."
 msgstr ""
+"Fortran использует статическую и сильную типизацию, что позволяет "
+"компилятору отлавливать многие ошибки программирования на ранних стадиях. "
+"Это также позволяет компилятору генерировать эффективный двоичный код."
 
 #: ../../source/index.md:32
 msgid "Easy to learn and use"
-msgstr ""
+msgstr "Простота изучения и использования"
 
 #: ../../source/index.md:35
 msgid ""
@@ -1754,20 +1767,27 @@ msgid ""
 " use. Expressing most mathematical and arithmetic operations over large "
 "arrays is as simple as writing them as equations on a whiteboard."
 msgstr ""
+"Fortran — это относительно небольшой язык, который удивительно прост в "
+"изучении и использовании. Выразить большинство математических и "
+"арифметических операций над большими массивами так же просто, как написать "
+"их в виде уравнений на доске."
 
 #: ../../source/index.md:38
 msgid "Versatile"
-msgstr ""
+msgstr "Универсальность"
 
 #: ../../source/index.md:41
 msgid ""
 "Fortran allows you to write code in a style that best fits your problem: "
 "imperative, procedural, array-oriented, object-oriented, or functional."
 msgstr ""
+"Fortran позволяет писать программы, используя подход, который лучше всего "
+"подходит для решения вашей задачи: императивный, процедурный, "
+"ориентированный на массивы, объектно-ориентированный или функциональный."
 
 #: ../../source/index.md:44
 msgid "Natively parallel"
-msgstr ""
+msgstr "Встроенный параллелизм"
 
 #: ../../source/index.md:47
 msgid ""
@@ -1778,14 +1798,22 @@ msgid ""
 "subroutines allow you to express different parallel programming patterns that"
 " best fit your problem at hand."
 msgstr ""
+"Fortran — это язык программирования со встроенной поддержкой параллельных "
+"вычислений с интуитивно понятным синтаксисом, похожим на синтаксис массивов, "
+"для обмена данными между процессорами. Вы можете запускать практически один "
+"и тот же код на одном процессоре, на многоядерной системе с общей памятью "
+"или на HPC с распределенной памятью или облачной системе. Комассивы, группы, "
+"события и коллективные процедуры позволяют выражать различные модели "
+"параллельного программирования, которые наилучшим образом соответствуют "
+"поставленной задаче."
 
 #: ../../source/index.md:50
 msgid "FAQ"
-msgstr ""
+msgstr "Часто задаваемые вопросы"
 
 #: ../../source/index.md:54
 msgid "What is the status of Fortran?"
-msgstr ""
+msgstr "Каков статус языка Fortran?"
 
 #: ../../source/index.md:57
 msgid ""
@@ -1799,10 +1827,20 @@ msgid ""
 "Library](https://github.com/fortran-lang/stdlib) and the [Fortran Package "
 "Manager](https://fpm.fortran-lang.org) are under active development."
 msgstr ""
+"Fortran является зрелым языком и при этом находится в стадии активного "
+"развития. Последний стандарт языка — [Fortran 2018](https://isotc.iso.org/"
+"livelink/livelink?func=ll&objId=19441669&objAction=Open). Следующий "
+"разрабатываемый стандарт, [Fortran 2023](https://wg5-fortran.org/N2151-N2200/"
+"N2194.pdf), планируется выпустить в 2023 году. Существует более десятка "
+"открытых и проприетарных [компиляторов Fortran](compilers). Кроме того, "
+"активно разрабатываются такие проекты с открытым исходным кодом, как ["
+"Стандартная Библиотека (Standard Library)](https://github.com/fortran-lang/"
+"stdlib) и [Менеджер пакетов для языка Fortran (Fortran Package "
+"Manager)](https://fpm.fortran-lang.org)."
 
 #: ../../source/index.md:71
 msgid "What is Fortran used for?"
-msgstr ""
+msgstr "Для чего используется Fortran?"
 
 #: ../../source/index.md:74
 msgid ""
@@ -1812,10 +1850,17 @@ msgid ""
 "is the dominant language of High Performance Computing and is used to "
 "[benchmark the fastest supercomputers in the world](https://top500.org/)."
 msgstr ""
+"Fortran в основном используется в областях, где вычисления традиционно "
+"использовались ранее -- в науке и проектировании. К ним относятся численное "
+"прогнозирование погоды и состояния океана, вычислительная гидродинамика, "
+"прикладная математика, статистика и финансовое дело. Fortran является "
+"основным языком, использующимся в высокопроизводительных вычислениях (HPC) и "
+"используется в [тестах производительности быстрейших суперкомпьютеров "
+"мира](https://top500.org/)."
 
 #: ../../source/index.md:77
 msgid "Should I use Fortran for my new project?"
-msgstr ""
+msgstr "Стоит ли мне использовать Fortran для моего нового проекта?"
 
 #: ../../source/index.md:80
 msgid ""
@@ -1823,14 +1868,17 @@ msgid ""
 "computation over large numeric arrays, Fortran is the optimal tool for the "
 "job."
 msgstr ""
+"Если вы пишете программу или библиотеку для выполнения быстрых "
+"арифметических вычислений над большими числовыми массивами, Fortran – "
+"оптимальный инструмент для такой работы."
 
 #: ../../source/index.md:109
 msgid "Make Fortran better"
-msgstr ""
+msgstr "Сделать Fortran лучше"
 
 #: ../../source/index.md:119
 msgid "Write proposals"
-msgstr ""
+msgstr "Вносите предложения"
 
 #: ../../source/index.md:122
 msgid ""
@@ -1838,10 +1886,14 @@ msgid ""
 "or contribute to existing proposals to the Fortran Standard Committee on "
 "[GitHub](https://github.com/j3-fortran/fortran_proposals)."
 msgstr ""
+"У вас есть идея как улучшить язык? Вы можете написать новые предложения или "
+"внести вклад в существующие предложения для Комитета по стандарту языка "
+"Fortran на странице в [GitHub](https://github.com/j3-fortran/"
+"fortran_proposals)."
 
 #: ../../source/index.md:130
 msgid "Develop tools"
-msgstr ""
+msgstr "Разрабатывайте инструменты"
 
 #: ../../source/index.md:133
 msgid ""
@@ -1850,48 +1902,59 @@ msgid ""
 "Manager](https://github.com/fortran-lang/fpm), [this "
 "website](https://github.com/fortran-lang/webpage)."
 msgstr ""
+"Вы также можете помочь сделать Fortran лучше, внося свой вклад в набор "
+"инструментов, таких как [Стандартная Библиотека](https://github.com/"
+"fortran-lang/stdlib), [Менеджер пакетов для языка Fortran](https://github."
+"com/fortran-lang/fpm), или [этот веб-сайт](https://github.com/fortran-lang/"
+"webpage)."
 
 #: ../../source/index.md:144
 msgid "Write Fortran software"
-msgstr ""
+msgstr "Пишите программы на Fortran"
 
 #: ../../source/index.md:147
 msgid ""
 "Or just write Fortran software for your research, business, or schoolwork. "
 "You can learn how to [get started here](learn)."
 msgstr ""
+"Или просто пишите программы на Fortran для своих исследований, бизнеса или "
+"учёбы. Вы можете узнать, как [начать обучение языку здесь](learn)."
 
 #: ../../source/learn.md:5
 msgid "Learn"
-msgstr ""
+msgstr "Обучение"
 
 #: ../../source/learn.md:8
 msgid "Learn Fortran"
-msgstr ""
+msgstr "Обучение языку Fotran"
 
 #: ../../source/learn.md:12
 msgid "Learning resources for beginners and experts alike"
-msgstr ""
+msgstr "Учебные ресурсы как для новичков, так и для экспертов"
 
 #: ../../source/learn.md:16
 msgid "Getting Started"
-msgstr ""
+msgstr "Первые шаги"
 
 #: ../../source/learn.md:31
 msgid ""
 "Try the quickstart Fortran tutorial, to get an overview of the language "
 "syntax and capabilities."
 msgstr ""
+"Ознакомьтесь с кратким руководством по языку Fortran, чтобы получить общее "
+"представление о синтаксисе и возможностях языка."
 
 #: ../../source/learn.md:40
 msgid "{octicon}``book;1em;sd-text-info`` Quickstart tutorial"
-msgstr ""
+msgstr "{octicon}``book;1em;sd-text-info`` Краткое руководство"
 
 #: ../../source/learn.md:55
 msgid ""
 "Ask a question in the Fortran-lang discourse - a forum for friendly "
 "discussion of all things Fortran."
 msgstr ""
+"Задайте вопрос в Fortran-lang Discourse - форуме (англоязычном) для "
+"дружеского обсуждения всего, что связано с Fortran."
 
 #: ../../source/learn.md:64
 msgid "{octicon}``check-circle;1em;sd-text-info`` Fortran-lang Discourse"
@@ -1899,75 +1962,89 @@ msgstr ""
 
 #: ../../source/learn.md:73
 msgid "Mini-book Tutorials"
-msgstr ""
+msgstr "Краткие руководства"
 
 #: ../../source/learn.md:80 ../../source/learn/building_programs/project_make.md:33
 msgid "Getting started"
-msgstr ""
+msgstr "Первые шаги"
 
 #: ../../source/learn.md:94
 msgid ""
 "{octicon}`book;1em;sd-text-info` <a href='../learn/quickstart/'>Quickstart "
 "Fortran Tutorial</a>"
 msgstr ""
+"{octicon}`book;1em;sd-text-info` <a href='../learn/quickstart/'>Краткое "
+"руководство по языку Fortran</a>"
 
 #: ../../source/learn.md:96
 msgid "An introduction to the Fortran syntax and its capabilities"
-msgstr ""
+msgstr "Введение в синтаксис языка Fortran и его возможности"
 
 #: ../../source/learn.md:108
 msgid ""
 "{octicon}`book;1em;sd-text-info` <a "
 "href='../learn/building_programs/'>Building programs</a>"
 msgstr ""
+"{octicon}`book;1em;sd-text-info` <a href='../learn/building_programs/"
+"'>Сборка программ</a>"
 
 #: ../../source/learn.md:110
 msgid "How to use the compiler to build an executable program"
-msgstr ""
+msgstr "Как использовать компилятор для сборки исполняемой программы"
 
 #: ../../source/learn.md:122
 msgid ""
 "{octicon}`book;1em;sd-text-info` <a href='../learn/os_setup/'>Setting up your"
 " OS</a>"
 msgstr ""
+"{octicon}`book;1em;sd-text-info` <a href='../learn/os_setup/'>Настройка "
+"операционной системы</a>"
 
 #: ../../source/learn.md:124
 msgid ""
 "How to install a Fortran compiler and set up a development environment in "
 "Windows, Linux and macOS."
 msgstr ""
+"Как установить компилятор Fortran и настроить среду разработки в Windows, "
+"Linux и macOS."
 
 #: ../../source/learn.md:136
 msgid ""
 "{octicon}`book;1em;sd-text-info` <a href='../learn/best_practices/'>Fortran "
 "Best Practices</a>"
 msgstr ""
+"{octicon}`book;1em;sd-text-info` <a href='../learn/best_practices/'>Лучшие "
+"практические методы языка Fortran</a>"
 
 #: ../../source/learn.md:138
 msgid "This tutorial collects a modern canonical way of doing things in Fortran."
 msgstr ""
+"Это руководство содержит современные канонические способы реализаций задач "
+"на языке Fortran."
 
 #: ../../source/learn.md:147
 msgid "Fortran Documentation"
-msgstr ""
+msgstr "Документация по языку Fortran"
 
 #: ../../source/learn.md:169
 msgid ""
 "{octicon}`book;1em;sd-text-info` <a href='../learn/intrinsics/'>Fortran "
 "Intrinsics</a>"
 msgstr ""
+"{octicon}`book;1em;sd-text-info` <a href='../learn/intrinsics/'>Встроенные "
+"функции и процедуры языка Fortran</a>"
 
 #: ../../source/learn.md:171
 msgid "man-pages for the Fortran Intrinsics"
-msgstr ""
+msgstr "man-страницы по встроенным функциям и процедурам языка Fortran"
 
 #: ../../source/learn.md:179
 msgid "Other Resources"
-msgstr ""
+msgstr "Другие ресурсы"
 
 #: ../../source/learn.md:184
 msgid "On the web"
-msgstr ""
+msgstr "В сети"
 
 #: ../../source/learn.md:190
 msgid ""
@@ -2022,7 +2099,7 @@ msgstr ""
 
 #: ../../source/learn.md:226
 msgid "Online Courses"
-msgstr ""
+msgstr "Онлайн курсы"
 
 #: ../../source/learn.md:232
 msgid ""
@@ -2227,7 +2304,7 @@ msgstr ""
 
 #: ../../source/learn.md:352
 msgid "In print"
-msgstr ""
+msgstr "В печати"
 
 #: ../../source/learn.md:358
 msgid ""
@@ -17504,7 +17581,7 @@ msgstr ""
 #: ../../source/learn/quickstart/arrays_strings.md:1
 #: ../../source/learn/quickstart/index.md:11
 msgid "Arrays and strings"
-msgstr ""
+msgstr "Массивы и строки"
 
 #: ../../source/learn/quickstart/arrays_strings.md:3
 msgid ""
@@ -17512,22 +17589,30 @@ msgid ""
 " opposed to just the single scalar variables that we have been using so far; "
 "in computer programming such lists are called _arrays_."
 msgstr ""
+"Чаще всего нам нужно хранить и использовать длинные списки чисел, а не "
+"отдельные скалярные переменные, которые мы использовали ранее; в языках "
+"программирования такие списки называют _arrays_ (массивы)."
 
 #: ../../source/learn/quickstart/arrays_strings.md:6
 msgid ""
 "Arrays are _multidimensional_ variables that contain more than one value "
 "where each value is accessed using one or more indices."
 msgstr ""
+"Массивы -- _многомерные_ переменные, содержащие более одного значения, при "
+"этом доступ к каждому значению осуществляется с помощью одного или "
+"нескольких индексов."
 
 #: ../../source/learn/quickstart/arrays_strings.md:9
 msgid ""
 "Arrays in Fortran are _one-based_ by default; this means that the first "
 "element along any dimension is at index 1."
 msgstr ""
+"Массивы в Fortran используют _нумерацию с отчётом от 1_ по умолчанию; это "
+"означает, что первый элемент вдоль любого измерения будет иметь индекс 1."
 
 #: ../../source/learn/quickstart/arrays_strings.md:12
 msgid "Array declaration"
-msgstr ""
+msgstr "Объявление массива"
 
 #: ../../source/learn/quickstart/arrays_strings.md:14
 msgid ""
@@ -17535,14 +17620,18 @@ msgid ""
 "declaring array variables: using the `dimension` attribute or by appending "
 "the array dimensions in parentheses to the variable name."
 msgstr ""
+"Мы можем объявить массивы любого типа. Существуют два распространённых "
+"способа (нотации) для объявления массива: использование атрибута `dimension` "
+"или указание размерности массива в круглых скобках после имени переменной "
+"обозначающей массив."
 
 #: ../../source/learn/quickstart/arrays_strings.md:17
 msgid "**Example:** static array declaration"
-msgstr ""
+msgstr "**Пример:** объявление статического массива"
 
 #: ../../source/learn/quickstart/arrays_strings.md:39
 msgid "Array slicing"
-msgstr ""
+msgstr "Срез массива"
 
 #: ../../source/learn/quickstart/arrays_strings.md:41
 msgid ""
@@ -17550,20 +17639,27 @@ msgid ""
 "operations; we can perform operations on all or part of an array using array "
 "_slicing_ notation:"
 msgstr ""
+"Мощной особенностью языка Fortran является встроенная поддержка операций над "
+"массивами; мы можем выполнять операции над всем массивом или его частью, "
+"используя операцию получения среза _slicing_, указав в скобках после имени "
+"массива диапазон индексов, и, если необходимо, шаг, разделив начальный, "
+"конечный индексы и шаг двоеточием (`:`):"
 
 #: ../../source/learn/quickstart/arrays_strings.md:44
 msgid "**Example:** array slicing"
-msgstr ""
+msgstr "**Пример:** срез массива"
 
 #: ../../source/learn/quickstart/arrays_strings.md:67
 msgid ""
 "Fortran arrays are stored in _column-major_ order; the first index varies "
 "fastest."
 msgstr ""
+"Массивы в Fortran хранятся в памяти _по столбцам_; первый индекс меняется "
+"быстрее."
 
 #: ../../source/learn/quickstart/arrays_strings.md:70
 msgid "Allocatable (dynamic) arrays"
-msgstr ""
+msgstr "Выделяемые (динамические) массивы"
 
 #: ../../source/learn/quickstart/arrays_strings.md:72
 msgid ""
@@ -17571,44 +17667,55 @@ msgid ""
 "type of array is known as a _static_ array since its size is fixed when we "
 "compile our program."
 msgstr ""
+"До сих пор мы указывали размер массива в коде программы --- такой массив "
+"называется _статическим_ массивом, так как его размер фиксирован при "
+"компиляции нашей программы."
 
 #: ../../source/learn/quickstart/arrays_strings.md:76
 msgid ""
 "Quite often, we do not know how big our array needs to be until we run our "
 "program, for example, if we are reading data from a file of unknown size."
 msgstr ""
+"Достаточно часто нам неизвестно какого размера должен быть массив, до "
+"запуска программы, например, если мы читаем данные из файла неизвестного "
+"размера."
 
 #: ../../source/learn/quickstart/arrays_strings.md:78
 msgid ""
 "For this problem, we need `allocatable` arrays. These are _allocated_ while "
 "the program is running once we know how big the array needs to be."
 msgstr ""
+"Для решения этой проблемы нам нужны `выделяемые` (динамические) массивы. "
+"Память под них _выделяется_ во время выполнения программы, когда мы узнаём "
+"какого размера должен быть массив."
 
 #: ../../source/learn/quickstart/arrays_strings.md:81
 msgid "**Example:** allocatable arrays"
-msgstr ""
+msgstr "**Пример:** выделяемые (динамические) массивы"
 
 #: ../../source/learn/quickstart/arrays_strings.md:101
 msgid ""
 "Allocatable local arrays are deallocated automatically when they go out of "
 "scope."
 msgstr ""
+"Память выделенная под локальные динамические массивы высвобождается "
+"автоматически когда происходит выход из области их видимости."
 
 #: ../../source/learn/quickstart/arrays_strings.md:104
 msgid "Character strings"
-msgstr ""
+msgstr "Символьные строки"
 
 #: ../../source/learn/quickstart/arrays_strings.md:106
 msgid "**Example:** static character string"
-msgstr ""
+msgstr "**Пример:** статические символьные строки"
 
 #: ../../source/learn/quickstart/arrays_strings.md:127
 msgid "**Example:** allocatable character string"
-msgstr ""
+msgstr "**Пример:** выделяемые (динамические) символьные строки"
 
 #: ../../source/learn/quickstart/arrays_strings.md:148
 msgid "Array of strings"
-msgstr ""
+msgstr "Массив строк"
 
 #: ../../source/learn/quickstart/arrays_strings.md:150
 msgid ""
@@ -17620,15 +17727,23 @@ msgid ""
 "of the `character` array. Finally, we use the intrinsic function `trim` to "
 "remove any excess spaces when printing the values to the standard output."
 msgstr ""
+"Массив строк в Fortran может быть представлен как массив переменных "
+"символьного типа `character`. Все элементы в массиве типа `character` имеют "
+"одинаковую длину. Однако в конструктор массива можно ввести строки разной "
+"длины, как показано в примере ниже. Они будут усечены или дополнены "
+"пробелами справа, если они длиннее или короче, соответственно, чем "
+"объявленная длина `character` (символьного) массива. Наконец, мы используем "
+"встроенную функцию `trim`, для удаления лишних пробелов при печати значений "
+"в стандартный вывод."
 
 #: ../../source/learn/quickstart/arrays_strings.md:156
 msgid "**Example:** string array"
-msgstr ""
+msgstr "**Пример:** массив строк"
 
 #: ../../source/learn/quickstart/derived_types.md:1
 #: ../../source/learn/quickstart/index.md:11
 msgid "Derived Types"
-msgstr ""
+msgstr "Производные типы данных"
 
 #: ../../source/learn/quickstart/derived_types.md:3
 msgid ""
@@ -17637,22 +17752,31 @@ msgid ""
 "can encapsulate other built-in types as well as other derived types. It could"
 " be considered equivalent to _struct_ in the C and C++ programming languages."
 msgstr ""
+"Как уже говорилось в разделе [Переменные](variables), в языке Fortran "
+"существуют пять встроенных типов данных. _Производный тип данных_ -- особая "
+"форма типа данных, которая может включать в себя другие встроенные типы "
+"данных,а также другие производные типы данных. Его можно считать "
+"эквивалентом _структуры_ в языках программирования C и C++."
 
 #: ../../source/learn/quickstart/derived_types.md:5
 msgid "A quick take on derived types"
-msgstr ""
+msgstr "Кратко о производных типах данных"
 
 #: ../../source/learn/quickstart/derived_types.md:7
 msgid "Here's an example of a basic derived type:"
-msgstr ""
+msgstr "Пример базового производного типа данных:"
 
 #: ../../source/learn/quickstart/derived_types.md:16
 msgid "The syntax to create a variable of type `t_pair` and access its members is:"
 msgstr ""
+"Синтаксис для создания переменной типа `t_pair` и доступа к её компонентам "
+"следующий:"
 
 #: ../../source/learn/quickstart/derived_types.md:26
 msgid "The percentage symbol `%` is used to access the members of a derived type."
 msgstr ""
+"Символ процента `%` используется для доступа к компоненту производного типа "
+"данных."
 
 #: ../../source/learn/quickstart/derived_types.md:28
 msgid ""
@@ -17660,40 +17784,49 @@ msgid ""
 "initialized its members explicitly. You can also initialize derived type "
 "members by invoking the derived type constructor."
 msgstr ""
+"В приведённом выше фрагменте мы объявили экземпляр производного типа данных "
+"и инициализировали его компоненты в явном виде. Вы также можете "
+"инициализировать компоненты производного типа данных, вызвав конструктор "
+"производного типа данных."
 
 #: ../../source/learn/quickstart/derived_types.md:31
 msgid "Example using the derived type constructor:"
-msgstr ""
+msgstr "Пример использования конструктора производного типа данных:"
 
 #: ../../source/learn/quickstart/derived_types.md:39
 msgid "Example with default initialization:"
-msgstr ""
+msgstr "Пример с инициализацией по умолчанию:"
 
 #: ../../source/learn/quickstart/derived_types.md:53
 msgid "Derived types in detail"
-msgstr ""
+msgstr "Производные типы данных в деталях"
 
 #: ../../source/learn/quickstart/derived_types.md:55
 msgid ""
 "The full syntax of a derived type with all optional properties is presented "
 "below:"
 msgstr ""
+"Полный синтаксис производного типа данных со всеми необязательными "
+"свойствами представлен ниже:"
 
 #: ../../source/learn/quickstart/derived_types.md:67
 msgid "Options to declare a derived type"
-msgstr ""
+msgstr "Параметры объявления производного типа данных"
 
 #: ../../source/learn/quickstart/derived_types.md:69
 msgid "`attribute-list` may refer to the following:"
-msgstr ""
+msgstr "`список атрибутов` может относиться к следующему:"
 
 #: ../../source/learn/quickstart/derived_types.md:71
 msgid "_access-type_ that is either `public` or `private`"
 msgstr ""
+"_тип доступа_, который может быть `public` (разрешение доступа для "
+"использования снаружи) или `private` (доступ для использования только внутри "
+"производного типа данных)"
 
 #: ../../source/learn/quickstart/derived_types.md:72
 msgid "`bind(c)` offers interoperability with C programming language"
-msgstr ""
+msgstr "`bind(c)` обеспечивает взаимодействие с языком программирования C"
 
 #: ../../source/learn/quickstart/derived_types.md:73
 msgid ""
@@ -17701,18 +17834,25 @@ msgid ""
 "derived type from which the current derived type will inherit all its members"
 " and functionality"
 msgstr ""
+"`extends(`_parent_`)`, где _parent_ -- имя ранее объявленного производного "
+"типа данных, от которого текущий производный тип данных будет наследовать "
+"все свои компоненты и функциональность"
 
 #: ../../source/learn/quickstart/derived_types.md:74
 msgid ""
 "`abstract` -- an object oriented feature that is covered in the advanced "
 "programming tutorial"
 msgstr ""
+"`abstract` -- объектно-ориентированная функция, которая рассматривается в "
+"учебнике по продвинутому программированию"
 
 #: ../../source/learn/quickstart/derived_types.md:76
 msgid ""
 "If the attribute `bind(c)` or the statement `sequence` is used, then a "
 "derived type cannot have the attribute `extends` and vice versa."
 msgstr ""
+"Если используется атрибут `bind(c)` или оператор `sequence`, то производный "
+"тип данных не может иметь атрибут `extends` и наоборот."
 
 #: ../../source/learn/quickstart/derived_types.md:78
 msgid ""
@@ -17720,10 +17860,13 @@ msgid ""
 "members should be accessed in the same order as they are defined within the "
 "derived type."
 msgstr ""
+"Атрибут `sequence` может использоваться только для объявления того, что "
+"доступ к следующим компонентам должен осуществляться в том же порядке, в "
+"котором они определены в производном типе данных."
 
 #: ../../source/learn/quickstart/derived_types.md:80
 msgid "Example with `sequence`:"
-msgstr ""
+msgstr "Пример с атрибутом `sequence`:"
 
 #: ../../source/learn/quickstart/derived_types.md:93
 msgid ""
@@ -17732,6 +17875,11 @@ msgid ""
 "does not imply that these data types will be stored in memory in any "
 "particular form, i.e., there is no relation to the `contiguous` attribute."
 msgstr ""
+"Использование атрибута `sequence` предполагает, что типы данных, "
+"определённые ниже, не относятся ни к распределённому, ни у указательному "
+"типу. Кроме того, это не означает, что эти типы данных будут храниться в "
+"памяти в какой-либо определённой форме, т.е. нет никакой связи с атрибутом "
+"`contiguous`."
 
 #: ../../source/learn/quickstart/derived_types.md:95
 msgid ""
@@ -17739,20 +17887,25 @@ msgid ""
 "all member-variables declared below will be automatically assigned the "
 "attribute accordingly."
 msgstr ""
+"Атрибуты _типа доступа_ `public` и `private`, если они используются, "
+"объявляют, что всем переменным-компонентам, объявленным ниже, будет "
+"автоматически присвоен соответствующий атрибут."
 
 #: ../../source/learn/quickstart/derived_types.md:97
 msgid ""
 "The attribute `bind(c)` is used to achieve compatibility between Fortran's "
 "derived type and C's struct."
 msgstr ""
+"Атрибут `bind(c)` используется для достижения совместимости между "
+"производным типом данных языка Fotran и структурой языка C."
 
 #: ../../source/learn/quickstart/derived_types.md:99
 msgid "Example with `bind(c)`:"
-msgstr ""
+msgstr "Пример с атрибутом `bind(c)`:"
 
 #: ../../source/learn/quickstart/derived_types.md:113
 msgid "matches the following C struct type:"
-msgstr ""
+msgstr "что соответствует следующему виду структуры языка C:"
 
 #: ../../source/learn/quickstart/derived_types.md:121
 msgid ""
@@ -17760,6 +17913,10 @@ msgid ""
 "`sequence` and `extends` attributes. Furthermore it cannot contain any "
 "Fortran `pointer` or `allocatable` types."
 msgstr ""
+"Производный тип данных языка Fortran с атрибутом `bind(c)` не может иметь "
+"атрибуты `sequence` и `extends`. Кроме того, он не может содержать `pointer` "
+"(указатель) языка Fortran или `allocatable` (динамически выделяемый в памяти)"
+" тип данных."
 
 #: ../../source/learn/quickstart/derived_types.md:123
 msgid ""
@@ -17767,12 +17924,18 @@ msgid ""
 "parameters must be listed in place of `[parameterized-definition-statements]`"
 " and must be either `len` or `kind` parameters or both."
 msgstr ""
+"`parameterized-declaration-list` -- необязательный параметр. Если он "
+"используется, то параметры должны быть перечислены вместо `[parameterized-"
+"definition-statements]` и они должны быть либо параметрами `len`, либо `kind`"
+", либо и тем и другим."
 
 #: ../../source/learn/quickstart/derived_types.md:125
 msgid ""
 "Example of a derived type with `parameterized-declaration-list` and with the "
 "attribute `public`:"
 msgstr ""
+"Пример производного типа данных со списком `parameterized-declaration-list` "
+"и с атрибутом `public`:"
 
 #: ../../source/learn/quickstart/derived_types.md:149
 msgid ""
@@ -17780,6 +17943,10 @@ msgid ""
 "of `kind(0.0)` (single-precision floating-point). Therefore, it can be "
 "omitted, as is the case here in the declaration inside the main program."
 msgstr ""
+"В этом примере параметру `k` уже присвоено значение по умолчанию -- `kind(0."
+"0)` (число с плавающей точкой одинарной точности). Поэтому его можно "
+"опустить, как это сделано в данном случае при объявлении внутри основной "
+"программы."
 
 #: ../../source/learn/quickstart/derived_types.md:151
 msgid ""
@@ -17790,6 +17957,12 @@ msgid ""
 "attribute `public` in the above example, then the compiler would throw an "
 "error inside `program test`."
 msgstr ""
+"По умолчанию производные типы данных и их компоненты являются "
+"общедоступными. Однако в данном примере в начале модуля используется атрибут "
+"`private`. Поэтому всё внутри модуля будет по умолчанию иметь атрибут "
+"`private`, пока явно не будет объявлен атрибут `public`. Если в приведённом "
+"примере типу данных `t_matrix` не был бы присвоен атрибут `public` , то "
+"компилятор выдал бы ошибку внутри программы `program test`."
 
 #: ../../source/learn/quickstart/derived_types.md:153
 msgid ""
@@ -17799,14 +17972,20 @@ msgid ""
 "parent types: `type, extends(parent) :: child`. Here, `child` inherits all "
 "the members and functionality from `type :: parent`."
 msgstr ""
+"Атрибут `extends` был добавлен в стандарте F2003 и вводит важную особенность "
+"объектно-ориентированной парадигмы (ООП), а именно наследование. Он делает "
+"возможным повторно использовать код, позволяя дочерним типам данных "
+"происходить от расширяемых родительских типов данных: `type, extends(parent) "
+":: child`. Здесь, `child` наследует все компоненты и функциональность из "
+"типа данных `type :: parent`."
 
 #: ../../source/learn/quickstart/derived_types.md:155
 msgid "Example with the attribute `extends`:"
-msgstr ""
+msgstr "Пример с атрибутом `extends`:"
 
 #: ../../source/learn/quickstart/derived_types.md:216
 msgid "Options to declare members of a derived type"
-msgstr ""
+msgstr "Опции объявления компонентов производного типа данных"
 
 #: ../../source/learn/quickstart/derived_types.md:218
 msgid ""
@@ -17816,26 +17995,33 @@ msgid ""
 "can have their own extensive syntax, in form of: `type [,member-attributes] "
 ":: name[attr-dependent-spec][init]`"
 msgstr ""
+"`[member-variables]` относится к объявлению всех компонентов типов данных. "
+"Эти типы данных могут быть любыми встроенными типами данных и/или "
+"производными типами данных, как уже было показано в примерах выше. Однако "
+"переменные-компоненты могут иметь свой собственный расширенный синтаксис в "
+"виде: `type [,member-attributes] :: name[attr-dependent-spec][init]`"
 
 #: ../../source/learn/quickstart/derived_types.md:221
 msgid "`type`: any built-in type or other derived type"
-msgstr ""
+msgstr "`type`: любой встроенный тип данных или другой производный тип данных"
 
 #: ../../source/learn/quickstart/derived_types.md:223
 msgid "`member-attributes` (optional):"
-msgstr ""
+msgstr "`member-attributes` (необязательные атрибуты):"
 
 #: ../../source/learn/quickstart/derived_types.md:225
 msgid "`public` or `private` access attributes"
-msgstr ""
+msgstr "`public` или `private` атрибуты доступа"
 
 #: ../../source/learn/quickstart/derived_types.md:226
 msgid "`protected` access attribute"
-msgstr ""
+msgstr "`protected` (защищённый) атрибут доступа"
 
 #: ../../source/learn/quickstart/derived_types.md:227
 msgid "`allocatable` with or without `dimension` to specify a dynamic array"
 msgstr ""
+"`allocatable` (выделяемый) с атрибутом или без атрибута `dimension` для "
+"задания динамического массива"
 
 #: ../../source/learn/quickstart/derived_types.md:228
 msgid "`pointer`, `codimension`, `contiguous`, `volatile`, `asynchronous`"
@@ -17843,7 +18029,7 @@ msgstr ""
 
 #: ../../source/learn/quickstart/derived_types.md:230
 msgid "Examples of common cases:"
-msgstr ""
+msgstr "Примеры общих случаев:"
 
 #: ../../source/learn/quickstart/derived_types.md:252
 msgid ""
@@ -17854,10 +18040,16 @@ msgid ""
 "These features will be covered in detail in the upcoming _Advanced "
 "programing_ mini-book."
 msgstr ""
+"Следующие атрибуты: `pointer`, `codimension`, `contiguous`, `volatile`, "
+"`asynchronous` -- расширенные возможности, которые не будут рассматриваться "
+"в данном _Кратком руководстве_. Однако они приводятся здесь для того, чтобы "
+"читатели знали, что такие возможности существуют, и могли их распознать. Эти "
+"возможности будут подробно рассмотрены в предстоящем руководстве по "
+"_Продвинутому программированию_."
 
 #: ../../source/learn/quickstart/derived_types.md:254
 msgid "Type-bound procedures"
-msgstr ""
+msgstr "Подпрограммы производного типа данных"
 
 #: ../../source/learn/quickstart/derived_types.md:256
 msgid ""
@@ -17866,6 +18058,11 @@ msgid ""
 "the `contains` statement that, in turn, follows all member variable "
 "declarations."
 msgstr ""
+"Производный тип данных может содержать функции или процедуры, которые "
+"_привязаны_ к нему. Мы будем называть их _подпрограммами производного типа "
+"данных_. Подпрограммы производного типа данных размещаются после оператора "
+"`contains`, который, в свою очередь, размещается после объявления всех "
+"переменных-компонентов."
 
 #: ../../source/learn/quickstart/derived_types.md:258
 msgid ""
@@ -17873,14 +18070,17 @@ msgid ""
 "into OOP features of modern Fortran. For now we'll focus on a simple example "
 "to show their basic use."
 msgstr ""
+"Невозможно полностью описать подпрограммы производного типа данных, не "
+"углубляясь в особенности ООП современного Fotran. Сейчас мы остановимся на "
+"простом примере, чтобы показать их базовое использование."
 
 #: ../../source/learn/quickstart/derived_types.md:260
 msgid "Here's an example of a derived type with a basic type-bound procedure:"
-msgstr ""
+msgstr "Пример производного типа данных со встроенной в него подпрограммой:"
 
 #: ../../source/learn/quickstart/derived_types.md:304
 msgid "What is new:"
-msgstr ""
+msgstr "Что нового?:"
 
 #: ../../source/learn/quickstart/derived_types.md:306
 msgid ""
@@ -17889,6 +18089,10 @@ msgid ""
 "access its members and to automatically pass it as an argument when we invoke"
 " a type-bound procedure."
 msgstr ""
+"`self` -- произвольное имя, которое мы выбрали для представления экземпляра "
+"производного типа данных `t_square` внутри его функции. Это позволяет нам "
+"получить доступ к его компонентам и автоматически передавать его в качестве "
+"аргумента при вызове подпрограммы производного типа данных."
 
 #: ../../source/learn/quickstart/derived_types.md:307
 msgid ""
@@ -17897,6 +18101,10 @@ msgid ""
 "derived type that extends `t_square`. The keyword `class` introduces the OOP "
 "feature polymorphism."
 msgstr ""
+"Теперь мы используем `class(t_square)` вместо `type(t_square)` в интерфейсе "
+"функции `area`. Это позволяет нам вызывать функцию `area` для любого "
+"производным типа, который расширяет производный тип `t_square`. Ключевое "
+"слово `class` вводит свойство ООП -- полиморфизм."
 
 #: ../../source/learn/quickstart/derived_types.md:309
 msgid ""
@@ -17905,24 +18113,33 @@ msgid ""
 "sq%area()` or `print *, sq%area()`. If you define it instead as a subroutine,"
 " you can invoke it from its own `call` statement:"
 msgstr ""
+"В приведённом выше примере функция производного типа данных `area` "
+"определена как функция и может быть вызвана только в выражении, например, `x "
+"= sq%area()` или `print *, sq%area()`. Если вместо этого определить её как "
+"процедуру, то её можно вызывать с помощью оператора `call`:"
 
 #: ../../source/learn/quickstart/derived_types.md:328
 msgid ""
 "In contrast to the example with the type-bound function, we now have two "
 "arguments:"
 msgstr ""
+"В отличии от примера с функцией производного типа, теперь у нас два "
+"аргумента:"
 
 #: ../../source/learn/quickstart/derived_types.md:330
 msgid ""
 "`class(t_square), intent(in) :: self` -- the instance of the derived type "
 "itself"
 msgstr ""
+"`class(t_square), intent(in) :: self` -- сам экземпляр производного типа"
 
 #: ../../source/learn/quickstart/derived_types.md:331
 msgid ""
 "`real, intent(out) :: x` -- used to store the calculated area and return to "
 "the caller"
 msgstr ""
+"`real, intent(out) :: x` -- переменная, которая используется для хранения "
+"вычисленной площади и возврата значения"
 
 #: ../../source/learn/quickstart/hello_world.md:1
 #: ../../source/learn/quickstart/hello_world.md:38
@@ -17936,12 +18153,17 @@ msgid ""
 "ubiquitous [\"Hello, "
 "World!\"](https://en.wikipedia.org/wiki/%22Hello,_World!%22_program) example."
 msgstr ""
+"В этой части руководства мы напишем нашу первую программу на Fortran: "
+"повсеместно распространённый пример первой программы [\\\"Hello, World!\\\""
+"](https://en.wikipedia.org/wiki/%22Hello,_World!%22_program)."
 
 #: ../../source/learn/quickstart/hello_world.md:6
 msgid ""
 "However, before we can write our program, we need to ensure that we have a "
 "Fortran compiler set up."
 msgstr ""
+"Однако, прежде чем мы сможем написать нашу программу, нам необходимо "
+"убедиться, что у нас установлен компилятор Fortran."
 
 #: ../../source/learn/quickstart/hello_world.md:9
 msgid ""
@@ -17949,10 +18171,13 @@ msgid ""
 "code must be passed through a compiler to produce a machine executable that "
 "can be run."
 msgstr ""
+"Фортран является _компилируемым языком_, что означает, что после написания "
+"текста исходного кода программы, он должен быть передан компилятору для "
+"создания исполняемого файла программы, который можно будет запустить."
 
 #: ../../source/learn/quickstart/hello_world.md:12
 msgid "Compiler setup"
-msgstr ""
+msgstr "Установка компилятора"
 
 #: ../../source/learn/quickstart/hello_world.md:14
 msgid ""
@@ -17960,6 +18185,9 @@ msgid ""
 "compiler (gfortran)](https://gcc.gnu.org/fortran/), which is part of the [GNU"
 " Compiler Collection (GCC)](https://gcc.gnu.org/)."
 msgstr ""
+"В этом руководстве мы будем работать со свободным и открытым компилятором ["
+"GNU Fortran compiler (gfortran)](https://gcc.gnu.org/fortran/), который "
+"является частью [GNU Compiler Collection (GCC)](https://gcc.gnu.org/)."
 
 #: ../../source/learn/quickstart/hello_world.md:19
 msgid ""
@@ -17968,36 +18196,51 @@ msgid ""
 "[MacPorts](https://www.macports.org/). On Windows, you can get native "
 "binaries [here](http://www.equation.com/servlet/equation.cmd?fa=fortran)."
 msgstr ""
+"Чтобы установить компилятор gfortran в операционной системе Linux, "
+"используйте пакетный менеджер вашей системы. На macOS, вы можете установить "
+"gfortran используя [Homebrew](https://brew.sh/) или [MacPorts](https://www."
+"macports.org/). Для Windows, вы можете получить установочные файлы "
+"[здесь](http://www.equation.com/servlet/equation.cmd?fa=fortran)."
 
 #: ../../source/learn/quickstart/hello_world.md:23
 msgid ""
 "To check if you have _gfortran_ setup correctly, open a terminal and run the "
 "following command:"
 msgstr ""
+"Чтобы проверить, что компилятор _gfortran_ установлен провильно, откройте "
+"терминал и выполните команду:"
 
 #: ../../source/learn/quickstart/hello_world.md:29
 msgid "this should output something like:"
 msgstr ""
+"вывод на экран в результате её выполнения должен быть похож на следующий:"
 
 #: ../../source/learn/quickstart/hello_world.md:40
 msgid ""
 "Once you have set up your compiler, open a new file in your favourite code "
 "editor and enter the following:"
 msgstr ""
+"После установки компилятора, создайте новый файл в вашем любимом редакторе "
+"кода и наберите в нём следующий пример:"
 
 #: ../../source/learn/quickstart/hello_world.md:49
 msgid "Having saved your program to `hello.f90`, compile at the command line with:"
 msgstr ""
+"Сохраните файл вашей программы в файл `hello.f90` и соберите её, набрав и "
+"выполнив в командной строке:"
 
 #: ../../source/learn/quickstart/hello_world.md:55
 msgid ""
 "`.f90` is the standard file extension for modern Fortran source files. The 90"
 " refers to the first modern Fortran standard in 1990."
 msgstr ""
+"`.f90` -- стандартное расширение файла для исходного текста современного "
+"Fortran. Число 90 является отсылкой к первому современному стандарту Fortran "
+"1990 года."
 
 #: ../../source/learn/quickstart/hello_world.md:58
 msgid "To run your compiled program:"
-msgstr ""
+msgstr "Для запуска вашей скомпилированной программы выполните команду:"
 
 #: ../../source/learn/quickstart/hello_world.md:65
 msgid ""
@@ -18005,25 +18248,28 @@ msgid ""
 " In the next part of this tutorial, we will introduce variables for storing "
 "data."
 msgstr ""
+"Поздравляем, вы написали, скомпилировали и запустили свою первую программу "
+"на Fortran! В следующей части этого руководства мы расскажем о переменных "
+"для хранения данных."
 
 #: ../../source/learn/quickstart/index.md:11
 #: ../../source/learn/quickstart/variables.md:1
 msgid "Variables"
-msgstr ""
+msgstr "Переменные"
 
 #: ../../source/learn/quickstart/index.md:11
 #: ../../source/learn/quickstart/operators_control_flow.md:1
 msgid "Operators and flow control"
-msgstr ""
+msgstr "Операторы и поток управления"
 
 #: ../../source/learn/quickstart/index.md:11
 #: ../../source/learn/quickstart/organising_code.md:1
 msgid "Organising code structure"
-msgstr ""
+msgstr "Организация структуры кода"
 
 #: ../../source/learn/quickstart/index.md:1
 msgid "Quickstart tutorial"
-msgstr ""
+msgstr "Краткое руководство"
 
 #: ../../source/learn/quickstart/index.md:3
 msgid ""
@@ -18031,12 +18277,17 @@ msgid ""
 "language and its syntax for common structured programming concepts including:"
 " types, variables, arrays, control flow and functions."
 msgstr ""
+"В этом кратком руководстве приводится обзор языка программирования Fortran и "
+"его синтаксиса для общих концепций структурированного программирования, "
+"включая: типы данных, переменные, массивы, поток управления и функции."
 
 #: ../../source/learn/quickstart/index.md:7
 msgid ""
 "The contents of this tutorial are shown in the navigation bar on the left "
 "with the current page highlighted bold."
 msgstr ""
+"Содержание этого руководства отображено на навигационной панели слева, "
+"текущая страница выделена жирным шрифтом."
 
 #: ../../source/learn/quickstart/index.md:9
 msgid ""
@@ -18051,50 +18302,60 @@ msgid ""
 "program can decide which instructions to execute next based on a logical "
 "condition."
 msgstr ""
+"Одним из самых больших преимуществ компьютерных алгоритмов, по сравнению с "
+"простыми математическими формулами, является возможность _ветвления_ "
+"программы, когда программа может решать, какие инструкции выполнять дальше, "
+"основываясь на логическом условии."
 
 #: ../../source/learn/quickstart/operators_control_flow.md:7
 msgid "There are two main forms of controlling program flow:"
-msgstr ""
+msgstr "Существуют две основных формы управления потоком программы:"
 
 #: ../../source/learn/quickstart/operators_control_flow.md:9
 msgid ""
 "_Conditional_ (if): choose program path based on a boolean (true or false) "
 "value"
 msgstr ""
+"_Условный_ (if): выбор ветки исполнения программы на основе логического "
+"значения (true или false – истина или ложь)"
 
 #: ../../source/learn/quickstart/operators_control_flow.md:11
 msgid "_Loop_: repeat a portion of code multiple times"
-msgstr ""
+msgstr "_Цикл_: повторение части кода несколько раз"
 
 #: ../../source/learn/quickstart/operators_control_flow.md:13
 msgid "Logical operators"
-msgstr ""
+msgstr "Логические операторы"
 
 #: ../../source/learn/quickstart/operators_control_flow.md:15
 msgid ""
 "Before we use a conditional branching operator, we need to be able to form a "
 "logical expression."
 msgstr ""
+"Прежде чем использовать оператор условного ветвления, необходимо "
+"сформировать логическое выражение."
 
 #: ../../source/learn/quickstart/operators_control_flow.md:18
 msgid ""
 "To form a logical expression, the following set of relational operators are "
 "available:"
 msgstr ""
+"Для формирования логического выражения, доступен следующий набор операторов "
+"отношения:"
 
 #: ../../source/learn/quickstart/operators_control_flow.md
 #: ../../source/learn/quickstart/variables.md
 msgid "Operator &nbsp;"
-msgstr ""
+msgstr "Оператор &nbsp;"
 
 #: ../../source/learn/quickstart/operators_control_flow.md
 msgid "Alternative &nbsp;"
-msgstr ""
+msgstr "Альтернативная форма записи &nbsp;"
 
 #: ../../source/learn/quickstart/operators_control_flow.md
 #: ../../source/learn/quickstart/variables.md
 msgid "Description"
-msgstr ""
+msgstr "Описание"
 
 #: ../../source/learn/quickstart/operators_control_flow.md
 msgid "`==`"
@@ -18106,7 +18367,7 @@ msgstr ""
 
 #: ../../source/learn/quickstart/operators_control_flow.md
 msgid "Tests for equality of two operands"
-msgstr ""
+msgstr "Проверка равенства двух операндов"
 
 #: ../../source/learn/quickstart/operators_control_flow.md
 msgid "`/=`"
@@ -18118,7 +18379,7 @@ msgstr ""
 
 #: ../../source/learn/quickstart/operators_control_flow.md
 msgid "Test for inequality of two operands"
-msgstr ""
+msgstr "Проверка неравенства двух операндов"
 
 #: ../../source/learn/quickstart/operators_control_flow.md
 msgid "`> `"
@@ -18130,7 +18391,7 @@ msgstr ""
 
 #: ../../source/learn/quickstart/operators_control_flow.md
 msgid "Tests if left operand is strictly greater than right operand"
-msgstr ""
+msgstr "Проверка на то, что левый операнд строго больше правого операнда"
 
 #: ../../source/learn/quickstart/operators_control_flow.md
 msgid "`< `"
@@ -18142,7 +18403,7 @@ msgstr ""
 
 #: ../../source/learn/quickstart/operators_control_flow.md
 msgid "Tests if left operand is strictly less than right operand"
-msgstr ""
+msgstr "Проверка на то, что левый операнд строго меньше правого операнда"
 
 #: ../../source/learn/quickstart/operators_control_flow.md
 msgid "`>=`"
@@ -18154,7 +18415,7 @@ msgstr ""
 
 #: ../../source/learn/quickstart/operators_control_flow.md
 msgid "Tests if left operand is greater than or equal to right operand"
-msgstr ""
+msgstr "Проверка на то, что левый операнд больше или равен правому операнду"
 
 #: ../../source/learn/quickstart/operators_control_flow.md
 msgid "`<=`"
@@ -18166,11 +18427,11 @@ msgstr ""
 
 #: ../../source/learn/quickstart/operators_control_flow.md
 msgid "Tests if left operand is less than or equal to right operand"
-msgstr ""
+msgstr "Проверка на то, что левый операнд меньше или равен правому операнду"
 
 #: ../../source/learn/quickstart/operators_control_flow.md:31
 msgid "as well as the following logical operators:"
-msgstr ""
+msgstr "а также следующие логические операторы:"
 
 #: ../../source/learn/quickstart/operators_control_flow.md
 msgid "`.and.`"
@@ -18179,6 +18440,8 @@ msgstr ""
 #: ../../source/learn/quickstart/operators_control_flow.md
 msgid "TRUE if both left and right operands are TRUE"
 msgstr ""
+"TRUE (истина) если оба операнда (левый и правый) возвращают значение TRUE "
+"(истина)"
 
 #: ../../source/learn/quickstart/operators_control_flow.md
 msgid "`.or.`"
@@ -18187,6 +18450,8 @@ msgstr ""
 #: ../../source/learn/quickstart/operators_control_flow.md
 msgid "TRUE if either left or right or both operands are TRUE"
 msgstr ""
+"TRUE (истина) если либо левый, либо правый, либо оба операнда возвращают "
+"значение TRUE (истина)"
 
 #: ../../source/learn/quickstart/operators_control_flow.md
 msgid "`.not.`"
@@ -18194,7 +18459,7 @@ msgstr ""
 
 #: ../../source/learn/quickstart/operators_control_flow.md
 msgid "TRUE if right operand is FALSE"
-msgstr ""
+msgstr "TRUE (истина) если правый операнд возвращает значение FALSE (ложь)"
 
 #: ../../source/learn/quickstart/operators_control_flow.md
 msgid "`.eqv.`"
@@ -18203,6 +18468,8 @@ msgstr ""
 #: ../../source/learn/quickstart/operators_control_flow.md
 msgid "TRUE if left operand has same logical value as right operand"
 msgstr ""
+"TRUE (истина) если левый операнд имеет то же логическое значение, что и "
+"правый операнд"
 
 #: ../../source/learn/quickstart/operators_control_flow.md
 msgid "`.neqv.`"
@@ -18211,66 +18478,83 @@ msgstr ""
 #: ../../source/learn/quickstart/operators_control_flow.md
 msgid "TRUE if left operand has the opposite logical value as right operand"
 msgstr ""
+"TRUE (истина) если левый операнд противоположное логическое значение по "
+"сравнению с правым операндом"
 
 #: ../../source/learn/quickstart/operators_control_flow.md:43
 msgid "Conditional construct (`if`)"
-msgstr ""
+msgstr "Условная конструкция (`if`)"
 
 #: ../../source/learn/quickstart/operators_control_flow.md:45
 msgid ""
 "In the following examples, a conditional `if` construct is used to print out "
 "a message to describe the nature of the `angle` variable:"
 msgstr ""
+"В следующих примерах условная конструкция `if` используется для вывода "
+"сообщения для описания характера переменной `angle` (угол):"
 
 #: ../../source/learn/quickstart/operators_control_flow.md:48
 msgid "**Example:** single branch `if`"
-msgstr ""
+msgstr "**Пример:** одиночная ветвь `if`"
 
 #: ../../source/learn/quickstart/operators_control_flow.md:56
 msgid ""
 "In this first example, the code within the `if` construct is _only executed "
 "if_ the test expression (`angle < 90.0`) is true."
 msgstr ""
+"В этом первом примере код внутри конструкции `if` _выполняется только если_ "
+"тестовое выражение (`angle < 90.0`) истинно."
 
 #: ../../source/learn/quickstart/operators_control_flow.md:60
 msgid ""
 "It is good practice to indent code within constructs such as `if` and `do` to"
 " make code more readable."
 msgstr ""
+"Хорошей практикой считается добавление отступа внутри таких конструкций как "
+"`if` и `do`, чтобы сделать код более читабельным."
 
 #: ../../source/learn/quickstart/operators_control_flow.md:64
 msgid "We can add an alternative branch to the construct using the `else` keyword:"
 msgstr ""
+"Мы можем добавить альтернативную ветвь в конструкцию с помощью ключевого "
+"слова `else`:"
 
 #: ../../source/learn/quickstart/operators_control_flow.md:66
 msgid "**Example:** two-branch `if`-`else`"
-msgstr ""
+msgstr "**Example:** две ветви `if`-`else`"
 
 #: ../../source/learn/quickstart/operators_control_flow.md:76
 msgid ""
 "Now there are two _branches_ in the `if` construct, but _only one branch is "
 "executed_ depending on the logical expression following the `if` keyword."
 msgstr ""
+"Теперь в конструкции `if` есть две _ветви_, но _выполнятся только одна "
+"ветвь_ в зависимости от логического выражения, следующего за ключевым словом "
+"`if`."
 
 #: ../../source/learn/quickstart/operators_control_flow.md:79
 msgid ""
 "We can actually add any number of branches using `else if` to specify more "
 "conditions:"
 msgstr ""
+"Мы можем добавить любое количество ветвей с помощью ключевого слова `else if`"
+", чтобы задать больше условий:"
 
 #: ../../source/learn/quickstart/operators_control_flow.md:81
 msgid "**Example:** multi-branch `if`-`else if`-`else`"
-msgstr ""
+msgstr "**Пример:** множественное ветвление `if`-`else if`-`else`"
 
 #: ../../source/learn/quickstart/operators_control_flow.md:93
 msgid ""
 "When multiple conditional expressions are used, each conditional expression "
 "is tested only if none of the previous expressions have evaluated to true."
 msgstr ""
+"При использовании нескольких условных выражений, каждое условное выражение "
+"проверяется только в том случае, если ни одно из предыдущих не было истинно."
 
 #: ../../source/learn/quickstart/operators_control_flow.md:96
 msgid "Loop constructs (`do`)"
-msgstr ""
+msgstr "Конструкции циклов (`do`)"
 
 #: ../../source/learn/quickstart/operators_control_flow.md:98
 msgid ""
@@ -18279,6 +18563,11 @@ msgid ""
 "is used to track which iteration of the loop is currently executing. In this "
 "example we use a common name for this counter variable: `i`."
 msgstr ""
+"В следуем примере конструкция цикла `do` используется для вывода "
+"последовательности чисел. Цикл `do` имеет целочисленную переменную _счётчик_ "
+"(счётчик цикла), которая используется для отслеживания того, какая итерация "
+"цикла выполняется в данный момент. В этом примере мы используем принятое "
+"обычно для такой переменной счётчика имя: `i`."
 
 #: ../../source/learn/quickstart/operators_control_flow.md:103
 msgid ""
@@ -18286,18 +18575,21 @@ msgid ""
 "followed by an equals (`=`) sign to specify the start value and final value "
 "of our counting variable."
 msgstr ""
+"Когда мы определяем начало цикла `do`, мы используем имя нашей переменной "
+"счётчика, за которой следует знак присваивания (`=`), чтобы указать "
+"начальное и конечное значение нашего счётчика цикла."
 
 #: ../../source/learn/quickstart/operators_control_flow.md:106
 msgid "**Example:** `do` loop"
-msgstr ""
+msgstr "**Пример:** цикл `do`"
 
 #: ../../source/learn/quickstart/operators_control_flow.md:116
 msgid "**Example:** `do` loop with skip"
-msgstr ""
+msgstr "**Пример:** цикл `do` с заданием шага счётчика"
 
 #: ../../source/learn/quickstart/operators_control_flow.md:126
 msgid "Conditional loop (`do while`)"
-msgstr ""
+msgstr "Цикл с условием (`do while`)"
 
 #: ../../source/learn/quickstart/operators_control_flow.md:128
 msgid ""
@@ -18305,50 +18597,63 @@ msgid ""
 "will be executed while the condition given in `while()` evaluates to "
 "`.true.`."
 msgstr ""
+"В цикл `do` можно добавить проверку условия с помощью ключевого слова `while`"
+". Тогда цикл будет выполняться до тех пор, пока условие, заданное в `while()`"
+", истинно (`.true.`)."
 
 #: ../../source/learn/quickstart/operators_control_flow.md:131
 msgid "**Example:** `do while()` loop"
-msgstr ""
+msgstr "**Пример:** цикла `do while()`"
 
 #: ../../source/learn/quickstart/operators_control_flow.md:144
 msgid "Loop control statements (`exit` and `cycle`)"
-msgstr ""
+msgstr "Операторы управления циклом (`exit` and `cycle`)"
 
 #: ../../source/learn/quickstart/operators_control_flow.md:146
 msgid ""
 "Most often than not, loops need to be stopped if a condition is met. Fortran "
 "provides two executable statements to deal with such cases."
 msgstr ""
+"Часто бывает необходимо остановить выполнение цикла при выполнении какого-"
+"либо условия. Fortran предоставляет для таких случаев два оператора "
+"исполнения."
 
 #: ../../source/learn/quickstart/operators_control_flow.md:149
 msgid ""
 "`exit` is used to quit the loop prematurely. It is usually enclosed inside an"
 " `if`."
 msgstr ""
+"`exit` (выход) используется для преждевременного завершения цикла. Он обычно "
+"используется внутри условной конструкции `if`."
 
 #: ../../source/learn/quickstart/operators_control_flow.md:151
 msgid "**Example:** loop with `exit`"
-msgstr ""
+msgstr "**Пример:** цикл с оператором `exit`"
 
 #: ../../source/learn/quickstart/operators_control_flow.md:165
 msgid ""
 "On the other hand, `cycle` skips whatever is left of the loop and goes into "
 "the next cycle."
 msgstr ""
+"С другой стороны, оператор `cycle` принудительно заставляет программу "
+"пропустить выполнение всего, что осталось ниже него и перейти к выполнению "
+"следующей итерации цикла."
 
 #: ../../source/learn/quickstart/operators_control_flow.md:167
 msgid "**Example:** loop with `cycle`"
-msgstr ""
+msgstr "**Пример:** цикл с оператором `cycle`"
 
 #: ../../source/learn/quickstart/operators_control_flow.md:181
 msgid ""
 "When used within nested loops, the `cycle` and `exit` statements operate on "
 "the innermost loop."
 msgstr ""
+"При использовании внутри вложенных циклов операторы `cycle` и `exit` "
+"действуют на самый внутренний цикл внутри которого находятся."
 
 #: ../../source/learn/quickstart/operators_control_flow.md:184
 msgid "Nested loop control: tags"
-msgstr ""
+msgstr "Управление вложенным циклом: метки"
 
 #: ../../source/learn/quickstart/operators_control_flow.md:186
 msgid ""
@@ -18357,24 +18662,33 @@ msgid ""
 "the programmer to _tag_ or _name_ each loop. If loops are tagged, there are "
 "two potential benefits:"
 msgstr ""
+"В любом языке программирования часто встречается использование вложенных "
+"циклов. Вложенные циклы -- циклы, которые выполняются внутри другого цикла. "
+"Fortran позволяет программисту пометить или назвать каждый цикл _меткой_ или "
+"_именем_. Использование меток для циклов, даёт два потенциальных "
+"преимущества:"
 
 #: ../../source/learn/quickstart/operators_control_flow.md:188
 msgid "The readability of the code may be improved (when the naming is meaningful)."
 msgstr ""
+"Может быть улучшена читабельность кода (при условии, что имена меток "
+"осмысленные)."
 
 #: ../../source/learn/quickstart/operators_control_flow.md:189
 msgid ""
 "`exit` and `cycle` may be used with tags, which allows for very fine-grained "
 "control of the loops."
 msgstr ""
+"Операторы `exit` и `cycle` могут использоваться с метками, что позволяет "
+"очень тонко управлять переходами в циклах."
 
 #: ../../source/learn/quickstart/operators_control_flow.md:191
 msgid "**Example:** tagged nested loops"
-msgstr ""
+msgstr "**Пример:** вложенные циклы с метками"
 
 #: ../../source/learn/quickstart/operators_control_flow.md:206
 msgid "Parallelizable loop (`do concurrent`)"
-msgstr ""
+msgstr "Параллельное выполнение цикла (`do concurrent`)"
 
 #: ../../source/learn/quickstart/operators_control_flow.md:208
 msgid ""
@@ -18387,6 +18701,15 @@ msgid ""
 "only happen within each `do concurrent` loop. These requirements place "
 "restrictions on what can be placed within the loop body."
 msgstr ""
+"Оператор цикла `do concurrent` используется для явного указания, что _внутри "
+"цикла нет взаимозависимостей_; он сообщает компилятору, что возможно "
+"использовать распараллеливание/_SIMD_ для ускорения выполнения цикла и более "
+"явно передаёт намерения программиста. Более конкретно, это означает, что "
+"любая отдельная итерация цикла не зависит от выполнения предшествующих "
+"итераций этого цикла. Также необходимо, чтобы любые изменения состояния, "
+"которые могут произойти, происходили только внутри каждой итерации цикла `do "
+"concurrent`. Эти требования накладывают ограничения на то, что может быть "
+"размещено в теле такого цикла."
 
 #: ../../source/learn/quickstart/operators_control_flow.md:212
 msgid ""
@@ -18398,10 +18721,18 @@ msgid ""
 "calculation, like the below example). In general, compiler flags are required"
 " to activate possible parallelization for `do concurrent` loops."
 msgstr ""
+"Простая замена цикла `do` на цикл `do concurrent` не гарантирует "
+"параллельного выполнения. Приведённое выше объяснение не содержит всех "
+"требований, которые должны быть выполнены для написания корректного цикла `"
+"do concurrent`. Компиляторы также вольны поступать по своему усмотрению, то "
+"есть они могут не оптимизировать цикл (например, при небольшом количестве "
+"итераций для выполнения простого вычисления, как в примере ниже). В общем "
+"случае для активации возможного распараллеливания циклов `do concurrent` "
+"требуются использование дополнительных флагов компиляции."
 
 #: ../../source/learn/quickstart/operators_control_flow.md:218
 msgid "**Example:** `do concurrent()` loop"
-msgstr ""
+msgstr "**Пример:** цикл `do concurrent()`"
 
 #: ../../source/learn/quickstart/organising_code.md:3
 msgid ""
@@ -18409,20 +18740,25 @@ msgid ""
 "_procedures_ that can be reused by _calling_ them from other sections of "
 "code."
 msgstr ""
+"Большинство языков программирования позволяют объединять часто используемый "
+"код в _подпрограммы_, которые можно повторно использовать, _вызывая_ их из "
+"других частей кода."
 
 #: ../../source/learn/quickstart/organising_code.md:6
 msgid "Fortran has two forms of procedure:"
-msgstr ""
+msgstr "В языке Fortran доступно два вида подпрограмм:"
 
 #: ../../source/learn/quickstart/organising_code.md:8
 msgid "**Subroutine**: invoked by a `call` statement"
-msgstr ""
+msgstr "**Процедура**: вызывается оператором `call`"
 
 #: ../../source/learn/quickstart/organising_code.md:9
 msgid ""
 "**Function**: invoked within an expression or assignment to which it returns "
 "a value"
 msgstr ""
+"**Функция**: вызывается внутри выражения или присваивания, которому она "
+"возвращает значение"
 
 #: ../../source/learn/quickstart/organising_code.md:11
 msgid ""
@@ -18430,10 +18766,13 @@ msgid ""
 "by _argument association_; unless the `value` attribute is specified, this is"
 " similar to call by reference."
 msgstr ""
+"И процедуры, и функции имеют доступ к переменным в родительской области "
+"видимости по _ассоциации имён аргументов_; если не указан атрибут `value`, "
+"то это похоже на вызов по ссылке."
 
 #: ../../source/learn/quickstart/organising_code.md:14
 msgid "Subroutines"
-msgstr ""
+msgstr "Процедуры"
 
 #: ../../source/learn/quickstart/organising_code.md:16
 msgid ""
@@ -18442,12 +18781,16 @@ msgid ""
 "attributes are declared within the body of the subroutine just like local "
 "variables."
 msgstr ""
+"Входные аргументы процедур, известные как _фиктивные (пустые) аргументы_, "
+"указываются внутри круглых скобок после имени процедуры; типы и атрибуты "
+"фиктивных аргументов объявляются в теле процедуры так же, как и её локальные "
+"переменные."
 
 #: ../../source/learn/quickstart/organising_code.md:19
 #: ../../source/learn/quickstart/organising_code.md:111
 #: ../../source/learn/quickstart/variables.md:128
 msgid "**Example:**"
-msgstr ""
+msgstr "**Пример:**"
 
 #: ../../source/learn/quickstart/organising_code.md:38
 msgid ""
@@ -18457,6 +18800,12 @@ msgid ""
 " (`intent(inout)`) within the procedure. In this example, the subroutine does"
 " not modify its arguments, hence all arguments are `intent(in)`."
 msgstr ""
+"Обратите внимание на дополнительный атрибут `intent` при объявлении "
+"фиктивных аргументов; этот необязательный атрибут указывает компилятору, "
+"доступен ли аргумент 'только для чтения' (`intent(in)`), 'только для записи' "
+"(`intent(out)`) или 'для чтения и записи' (`intent(inout)`) внутри "
+"процедуры. В этом примере процедура не изменяет свои аргументы, поэтому все "
+"аргументы имеют атрибут `intent(in)`."
 
 #: ../../source/learn/quickstart/organising_code.md:42
 msgid ""
@@ -18464,10 +18813,13 @@ msgid ""
 "arguments; this allows the compiler to check for unintentional errors and "
 "provides self-documentation."
 msgstr ""
+"Хорошей практикой является всегда указывать атрибут `intent` для фиктивных "
+"аргументов; это позволяет компилятору найти непреднамеренные ошибки и "
+"обеспечивает самодокументирование кода."
 
 #: ../../source/learn/quickstart/organising_code.md:45
 msgid "We can call this subroutine from a program using a `call` statement:"
-msgstr ""
+msgstr "Мы можем вызвать процедуру из программы с помощью оператора `call`:"
 
 #: ../../source/learn/quickstart/organising_code.md:60
 msgid ""
@@ -18476,18 +18828,24 @@ msgid ""
 " will not be necessary if we place our subroutine in a module as described "
 "later."
 msgstr ""
+"Этот пример использует так называемый аргумент _с явным указанием образа_ "
+"массива, так как мы передали дополнительные переменные для описания размеров "
+"массива `A`; это не потребуется, если мы поместим нашу процедуру в модуль, "
+"как описано ниже."
 
 #: ../../source/learn/quickstart/organising_code.md:63
 msgid "Functions"
-msgstr ""
+msgstr "Функции"
 
 #: ../../source/learn/quickstart/organising_code.md:78
 msgid "In production code, the intrinsic function `norm2` should be used."
 msgstr ""
+"В коде программного продукта следует, вместо приведённой в примере, "
+"использовать встроенную функцию `norm2`."
 
 #: ../../source/learn/quickstart/organising_code.md:80
 msgid "To execute this function:"
-msgstr ""
+msgstr "Чтобы вызвать эту функцию:"
 
 #: ../../source/learn/quickstart/organising_code.md:96
 msgid ""
@@ -18496,10 +18854,14 @@ msgid ""
 " known as `pure` functions. Use subroutines if your procedure needs to modify"
 " its arguments."
 msgstr ""
+"Хорошей практикой программирования является когда функция не изменяет свои "
+"аргументы --- то есть, все аргументы функции должны иметь атрибут "
+"`intent(in)`. Такие функции называют `pure` (чистыми) функциями. Используйте "
+"процедуры, если ваша подпрограмма должна изменять свои аргументы."
 
 #: ../../source/learn/quickstart/organising_code.md:100
 msgid "Modules"
-msgstr ""
+msgstr "Модули"
 
 #: ../../source/learn/quickstart/organising_code.md:102
 msgid ""
@@ -18507,22 +18869,29 @@ msgid ""
 "procedures, and other modules through the `use` statement. They can contain "
 "data objects, type definitions, procedures, and interfaces."
 msgstr ""
+"Модули языка Fortran содержат определения, которые становятся доступными для "
+"программ, подпрограмм и других модулей с помощью оператора `use`. Они могут "
+"содержать объекты данных, определения типов, подпрограммы и интерфейсы."
 
 #: ../../source/learn/quickstart/organising_code.md:105
 msgid ""
 "Modules allow controlled scoping extension whereby entity access is made "
 "explicit"
 msgstr ""
+"Модули позволяют управлять областью видимости, когда доступ к объектам "
+"организуют явно"
 
 #: ../../source/learn/quickstart/organising_code.md:106
 msgid ""
 "Modules automatically generate explicit interfaces required for modern "
 "procedures"
 msgstr ""
+"Модули автоматически генерируют явные интерфейсы, необходимые для "
+"современных подпрограмм"
 
 #: ../../source/learn/quickstart/organising_code.md:108
 msgid "It is recommended to always place functions and subroutines within modules."
-msgstr ""
+msgstr "Рекомендуется всегда размещать функции и процедуры внутри модулей."
 
 #: ../../source/learn/quickstart/organising_code.md:140
 msgid ""
@@ -18532,24 +18901,32 @@ msgid ""
 "the required explicit interface for us. This results in a much simpler "
 "subroutine interface."
 msgstr ""
+"Сравните эту процедуру `print_matrix` с написанной вне модуля. Нам больше не "
+"нужно явно передавать размеры матрицы, и вместо этого мы можем "
+"воспользоваться аргументами с _неявным заданием образа_, поскольку модуль "
+"сгенерирует для нас необходимый явный интерфейс. Это приводит к "
+"значительному упрощению интерфейса процедуры."
 
 #: ../../source/learn/quickstart/organising_code.md:145
 msgid "To `use` the module within a program:"
-msgstr ""
+msgstr "Чтобы подключить модуль внутри программы, используется оператор `use`:"
 
 #: ../../source/learn/quickstart/organising_code.md:161
 msgid "**Example:** explicit import list"
-msgstr ""
+msgstr "**Пример:** явный список импорта"
 
 #: ../../source/learn/quickstart/organising_code.md:167
 msgid "**Example:** aliased import"
-msgstr ""
+msgstr "**Пример:** импорт по псевдониму"
 
 #: ../../source/learn/quickstart/organising_code.md:173
 msgid ""
 "Each module should be written in a separate `.f90` source file. Modules need "
 "to be compiled prior to any program units that `use` them."
 msgstr ""
+"Каждый модуль должен быть написан в отдельном файле исходного кода `.f90`. "
+"Модули должны быть скомпилированы до компиляции любых программных блоков, "
+"которые их подключают оператором `use`."
 
 #: ../../source/learn/quickstart/variables.md:3
 msgid ""
@@ -18557,36 +18934,49 @@ msgid ""
 "is a _strongly typed_ language, which means that each variable must have a "
 "type."
 msgstr ""
+"Переменные хранят информацию, которая может быть использована программой. "
+"Fortran – _строго типизированный_ язык программирования, то есть каждая "
+"переменная должна быть определённого типа."
 
 #: ../../source/learn/quickstart/variables.md:7
 msgid "There are 5 built-in data types in Fortran:"
-msgstr ""
+msgstr "В Fortran существует 5 встроенных типов данных:"
 
 #: ../../source/learn/quickstart/variables.md:9
 msgid "`integer` -- for data that represent whole numbers, positive or negative"
 msgstr ""
+"`integer` -- (целый) для данных, которые представляют собой целые числа, "
+"положительные или отрицательные"
 
 #: ../../source/learn/quickstart/variables.md:10
 msgid "`real` -- for floating-point data (not a whole number)"
 msgstr ""
+"`real` -- (вещественный) для данных в виде чисел с плавающей точкой (но не "
+"целых чисел)"
 
 #: ../../source/learn/quickstart/variables.md:11
 msgid "`complex` -- pair consisting of a real part and an imaginary part"
 msgstr ""
+"`complex` -- (комплексный) пара чисел, определяющих вещественную и мнимую "
+"часть"
 
 #: ../../source/learn/quickstart/variables.md:12
 msgid "`character` -- for text data"
-msgstr ""
+msgstr "`character` -- (символьный) для текстовых данных"
 
 #: ../../source/learn/quickstart/variables.md:13
 msgid "`logical` -- for data that represent boolean (true or false) values"
 msgstr ""
+"`logical` -- (логический) для данных, которые представляют логические "
+"величины (true или false, т.е. истина или ложь)"
 
 #: ../../source/learn/quickstart/variables.md:15
 msgid ""
 "Before we can use a variable, we must _declare_ it; this tells the compiler "
 "the variable type and any other variable attributes."
 msgstr ""
+"Прежде чем использовать переменную, мы должны _объявить_ её; объявление "
+"переменной сообщит компилятору тип переменной и её другие атрибуты."
 
 #: ../../source/learn/quickstart/variables.md:18
 msgid ""
@@ -18594,20 +18984,25 @@ msgid ""
 "variable is fixed when the program is compiled---variable types cannot change"
 " while the program is running."
 msgstr ""
+"Fortran -- _статически типизированный_ язык программирования, что означает, "
+"что тип каждой переменной фиксируется в момент компиляции программы --- тип "
+"переменной не может быть изменён во время выполнения программы."
 
 #: ../../source/learn/quickstart/variables.md:21
 msgid "Declaring variables"
-msgstr ""
+msgstr "Объявление переменных"
 
 #: ../../source/learn/quickstart/variables.md:23
 msgid "The syntax for declaring variables is:"
-msgstr ""
+msgstr "Синтаксис объявления переменных:"
 
 #: ../../source/learn/quickstart/variables.md:29
 msgid ""
 "where `<variable_type>` is one of the built-in variable types listed above "
 "and `<variable_name>` is the name that you would like to call your variable."
 msgstr ""
+"где `<variable_type>` -- один из встроенных типов данных, описанных выше и "
+"`<variable_name>` -- имя переменной, которым вы хотите обозначить переменную."
 
 #: ../../source/learn/quickstart/variables.md:32
 msgid ""
@@ -18615,10 +19010,13 @@ msgid ""
 "and underscores. In the following example we declare a variable for each of "
 "the built-in types."
 msgstr ""
+"Имена переменных должны начинаться с буквы и могут состоять из букв, цифр и "
+"символа нижнего подчёркивания. В следующем примере мы объявим переменную для "
+"каждого из встроенного типа данных."
 
 #: ../../source/learn/quickstart/variables.md:35
 msgid "**Example:** variable declaration"
-msgstr ""
+msgstr "**Пример:** объявление переменной"
 
 #: ../../source/learn/quickstart/variables.md:50
 msgid ""
@@ -18626,6 +19024,9 @@ msgid ""
 "capitalisation of your variable names, but it's good practice to keep it "
 "consistent."
 msgstr ""
+"Fortran -- **нечувствителен к регистру**; вы можете не беспокоиться о том, "
+"названы переменные с использованием заглавных букв или нет, но хорошей "
+"практикой будет сохранение постоянства их написания внутри текста программы."
 
 #: ../../source/learn/quickstart/variables.md:53
 msgid ""
@@ -18634,6 +19035,10 @@ msgid ""
 "explicitly declared; without this statement variables will be implicitly "
 "typed according to the letter they begin with."
 msgstr ""
+"Обратите внимание на дополнительный оператор в начале программы: `implicit "
+"none`. Этот оператор сообщает компилятору, что все переменные будут "
+"объявлены явно; без этого оператора переменным будет неявно присвоен тип в "
+"зависимости от буквы с которой начинается их имя."
 
 #: ../../source/learn/quickstart/variables.md:57
 msgid ""
@@ -18641,24 +19046,34 @@ msgid ""
 " procedure. Implicit typing is considered bad practice in modern programming "
 "since it hides information leading to more program errors."
 msgstr ""
+"Всегда используйте оператор `implicit none` в начале каждой программы и "
+"подпрограммы (процедуры или функции). Неявное присвоение типа считается "
+"плохой практикой в современном программировании, так как скрывает "
+"информацию, что в итоге приводит к большему числу программных ошибок."
 
 #: ../../source/learn/quickstart/variables.md:61
 msgid ""
 "Once we have declared a variable, we can assign and reassign values to it "
 "using the assignment operator `=`."
 msgstr ""
+"После объявления переменной, мы можем присваивать ей значения и "
+"переприсваивать значение, используя оператор присваивания `=`."
 
 #: ../../source/learn/quickstart/variables.md:63
 msgid "**Example:** variable assignment"
-msgstr ""
+msgstr "**Пример:** присваивание значения переменной"
 
 #: ../../source/learn/quickstart/variables.md:73
 msgid "Characters are surrounded by either single (`'`) or double quotes (`\"`)."
 msgstr ""
+"Символьные значения обрамляются одиночными (`'`) или двойными кавычками (`\\"
+"\"`)."
 
 #: ../../source/learn/quickstart/variables.md:75
 msgid "Logical or boolean values can be either `.true.` or `.false.`."
 msgstr ""
+"Логические или булевы величины могут быть равны `.true.` (истина) или `."
+"false.` (ложь)."
 
 #: ../../source/learn/quickstart/variables.md:77
 msgid ""
@@ -18667,42 +19082,57 @@ msgid ""
 "which means that the variable retains its value between procedure calls. Good"
 " practice is to initialise your variables separately to their declaration."
 msgstr ""
+"Осторожно используйте присваивание при объявлении: `integer :: amount = 1`. "
+"**Это НЕ ЯВЛЯЕТСЯ нормальным способом инициализации;** в этом случае неявно "
+"применяется атрибут `save`, который означает, что переменная сохраняет своё "
+"значение между вызовами подпрограммы (процедуры или функции). Хорошей "
+"практикой является инициализация ваших переменных отдельно от их объявления."
 
 #: ../../source/learn/quickstart/variables.md:81
 msgid "Standard input / output"
-msgstr ""
+msgstr "Стандартный ввод / вывод"
 
 #: ../../source/learn/quickstart/variables.md:83
 msgid ""
 "In our _Hello World_ example, we printed text to the command window. This is "
 "commonly referred to as writing to `standard output` or `stdout`."
 msgstr ""
+"В нашем примере программы _Hello World_, мы вывели текст в окно команд. "
+"Обычно такой вывод называется `standard output` (стандартным выводом) или "
+"`stdout`."
 
 #: ../../source/learn/quickstart/variables.md:86
 msgid ""
 "We can use the `print` statement introduced earlier to print variable values "
 "to `stdout`:"
 msgstr ""
+"Мы можем использовать оператор `print`, представленный ранее, для печати "
+"значений переменных в `stdout`:"
 
 #: ../../source/learn/quickstart/variables.md:96
 msgid ""
 "In a similar way, we can read values from the command window using the `read`"
 " statement:"
 msgstr ""
+"Аналогичным образом мы можем считывать значения из окна команд, используя "
+"оператор `read`:"
 
 #: ../../source/learn/quickstart/variables.md:112
 msgid "This input source is commonly referred to as `standard input` or `stdin`."
 msgstr ""
+"Такой ввод обычно называется `standard input` (стандартный ввод) или `stdin`."
 
 #: ../../source/learn/quickstart/variables.md:114
 msgid "Expressions"
-msgstr ""
+msgstr "Выражения"
 
 #: ../../source/learn/quickstart/variables.md:116
 msgid ""
 "The usual set of arithmetic operators are available, listed in order of "
 "precedence:"
 msgstr ""
+"В языке Fortran доступен обычный набор арифметических операторов, "
+"перечисленный ниже в порядке приоритета:"
 
 #: ../../source/learn/quickstart/variables.md
 msgid "`**`"
@@ -18710,7 +19140,7 @@ msgstr ""
 
 #: ../../source/learn/quickstart/variables.md
 msgid "Exponent"
-msgstr ""
+msgstr "Возведение в степень"
 
 #: ../../source/learn/quickstart/variables.md
 msgid "`*`"
@@ -18718,7 +19148,7 @@ msgstr ""
 
 #: ../../source/learn/quickstart/variables.md
 msgid "Multiplication"
-msgstr ""
+msgstr "Умножение"
 
 #: ../../source/learn/quickstart/variables.md
 msgid "`/ `"
@@ -18726,7 +19156,7 @@ msgstr ""
 
 #: ../../source/learn/quickstart/variables.md
 msgid "Division"
-msgstr ""
+msgstr "Деление"
 
 #: ../../source/learn/quickstart/variables.md
 msgid "`+`"
@@ -18734,7 +19164,7 @@ msgstr ""
 
 #: ../../source/learn/quickstart/variables.md
 msgid "Addition"
-msgstr ""
+msgstr "Сложение"
 
 #: ../../source/learn/quickstart/variables.md
 msgid "`-`"
@@ -18742,11 +19172,11 @@ msgstr ""
 
 #: ../../source/learn/quickstart/variables.md
 msgid "Subtraction"
-msgstr ""
+msgstr "Вычитание"
 
 #: ../../source/learn/quickstart/variables.md:159
 msgid "Floating-point precision"
-msgstr ""
+msgstr "Точность чисел с плавающей точкой"
 
 #: ../../source/learn/quickstart/variables.md:161
 msgid ""
@@ -18754,24 +19184,36 @@ msgid ""
 "`kind` parameter. The `iso_fortran_env` intrinsic module provides `kind` "
 "parameters for the common 32-bit and 64-bit floating-point types."
 msgstr ""
+"Желаемая точность (вещественных) чисел с плавающей точкой может быть явно "
+"указана с помощью параметра `kind`. Встроенный модуль `iso_fortran_env` "
+"предоставляет параметры `kind` для распространённых 32-битных (одинарная "
+"точность) и 64-битных (двойная точность) типов чисел с плавающей точкой."
 
 #: ../../source/learn/quickstart/variables.md:164
 msgid "**Example:** explicit real `kind`"
 msgstr ""
+"**Пример:** явное указание вещественного типа с помощью параметра `kind`"
 
 #: ../../source/learn/quickstart/variables.md:180
 msgid "Always use a `kind` suffix for floating-point literal constants."
 msgstr ""
+"Всегда используйте суффикс (в примере выше: `_sp` -- для одинарной, `_dp` -- "
+"для двойной точности) параметра `kind` для литеральных констант "
+"представленных в виде числа с плавающей точкой."
 
 #: ../../source/learn/quickstart/variables.md:182
 msgid "**Example:** C-interoperable `kind`"
 msgstr ""
+"**Пример:** C-интерпорабельный параметр `kind` (функционально совместимый с "
+"типом языка C)"
 
 #: ../../source/learn/quickstart/variables.md:195
 msgid ""
 "In the next part we will learn how to use arrays for storing more than one "
 "value in a variable."
 msgstr ""
+"В следующей части мы узнаем как использовать массивы для хранения более "
+"одного значения в переменной."
 
 #: ../../source/news.md:1
 msgid "News"
@@ -36051,4 +36493,3 @@ msgid ""
 "Tags:  {bdg-light}`split`  {bdg-light}`join`  {bdg-light}`basename`  {bdg-"
 "light}`search`  {bdg-light}`concat`"
 msgstr ""
-

--- a/source/_templates/version-switcher.html
+++ b/source/_templates/version-switcher.html
@@ -86,6 +86,11 @@
         url: "../pt/",
       },
       {
+        name: "ru",
+        version: "ru",
+        url: "../ru/",
+      },
+      {
         name: "zh_CN",
         version: "zh_CN",
         url: "../zh_CN/",
@@ -103,7 +108,7 @@
       node.textContent = `${entry.name}`;
       node.setAttribute(
         "href",
-        `${indexFilePath}${entry.url}${currentFilePath}`
+        `${indexFilePath}${entry.url}${currentFilePath}`,
       );
       // on click, AJAX calls will check if the linked page exists before
       // trying to redirect, and if not, will redirect to the homepage


### PR DESCRIPTION
This pull request introduce Russian translation of **webpage**, namely `index`, `learn`, `learn/quickstart/*` pages.

Attached zip tarball ([fortran-lang-org_ru_initial.zip](https://github.com/fortran-lang/webpage/files/9679432/fortran-lang-org_ru_initial.zip)) contains pdf-pages of built version of translated **webpage** for preview.

P.S.
`Makefile`: is also updated here.  
 `source/_templates/version-switcher.html`: The additional `comma` in this file was added by `prettier` hook.  

