### PR TITLE
Add Fortnet to package index

### DIFF
--- a/data/package_index.yml
+++ b/data/package_index.yml
@@ -1072,6 +1072,13 @@
   license: GPL-3.0
   tags: density-functional-theory
 
+- name: "Fortnet"
+  github: vanderhe/fortnet
+  description: "A software package for training Behler-Parrinello neural networks"
+  categories: scientific
+  license: LGPL-3.0-or-later
+  tags: machine-learning neural-networks bpnn atomistic-simulations
+
 - name: LATTE
   github: lanl/LATTE
   description: Open source density functional tight binding molecular dynamics


### PR DESCRIPTION
Adds Fortnet to the package index.

I confirm the following package criteria:

- [x] Relevance
- [x] Maturity
- [x] Availability
- [x] Open source
- [x] Uniqueness
- [x] README
- [x] Documentation
- [x] Contributing
- [x] Tests