### PR TITLE
fix URLs (for CMake and Arrays sections) and Quickstart confusing paragraph

### DIFF
--- a/source/learn/best_practices/arrays.md
+++ b/source/learn/best_practices/arrays.md
@@ -1,7 +1,7 @@
 # Arrays
 
 Arrays are a central object in Fortran. The creation of dynamic sized arrays
-is discussed in the [allocatable arrays section](./allocatable_arrays.html).
+is discussed in the [allocatable arrays section](./allocatable_arrays).
 
 To pass arrays to procedures four ways are available
 

--- a/source/learn/building_programs/build_tools.md
+++ b/source/learn/building_programs/build_tools.md
@@ -535,7 +535,7 @@ so we do not have to worry about the actual steps in the build process.
 
 ::::{tip}
 CMake's official reference can be found at the
-<a href="https://cmake.org/cmake/help/latest/", target="\_blank" rel="noopener">CMake webpage</a>.
+<a href="https://cmake.org/cmake/help/latest/" target="_blank" rel="noopener">CMake webpage</a>.
 It is organised in manpages, which are also available with your local CMake
 installation as well using `man cmake`. While it covers all functionality of
 CMake, it sometimes covers them only very briefly.

--- a/source/learn/quickstart/index.md
+++ b/source/learn/quickstart/index.md
@@ -6,8 +6,6 @@ types, variables, arrays, control flow and functions.
 
 The contents of this tutorial are shown in the navigation bar on the left with the current page highlighted bold.
 
-Use the _Next_ button at the bottom to start the tutorial with a _Hello World_ example.
-
 ```{toctree}
 :maxdepth: 2
 :hidden:


### PR DESCRIPTION
The 1st commit fix urls to make it visible (arrays url)  and working (cmake url).  
The 2nd remove paragrath about absent button.