### PR TITLE
Fix formatting in description for NEW_LINE

### DIFF
--- a/source/learn/intrinsics/_pages/NEW_LINE.md
+++ b/source/learn/intrinsics/_pages/NEW_LINE.md
@@ -36,17 +36,20 @@ WRITE() and PRINT() when each statement completes:
 ```
 
 produces:
-x=11
 
-    y=22
+```text
+   x=11
 
-````
+   y=22
+```
+
 Alternatively, a "/" descriptor in a format is used to generate a
 newline on the output. For example:
+
 ```fortran
    write(*,'(a,1x,i0,/,a)') 'x =',11,'is the answer'
    end
-````
+```
 
 produces:
 


### PR DESCRIPTION
This fixes a broken code block that was causing the page to display incorrectly.
It also removes an extra `` ` `` from the code block below.