### PR TITLE
Updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,18 @@ To install the dependencies of this project, use commamd:
 pip3 install --user -r requirements.txt
 ```
 
+To install sphinx (if system is not able to recognize sphinx-build after installing requirements) :
+
+First check :
+```
+sphinx-build --version
+```
+
+if not recognized then run:
+```
+pip install -U sphinx
+```
+
 Build the site by invoking
 
 ```


### PR DESCRIPTION
After installing requirements the system was **not able to recognize sphinx-build** so I had to install sphinx separately as per their **official documentation** and was able to setup the webpage successfully after installing it.

The command that I used was - **pip install -U sphinx**