### PR TITLE
Correct gFTL package category

### DIFF
--- a/data/package_index.yml
+++ b/data/package_index.yml
@@ -434,6 +434,20 @@
   version: none
   license: LGPL-3.0-or-later
 
+- name: gFTL
+  github: Goddard-Fortran-Ecosystem/gFTL
+  description: Templates for STL-like Fortran implementations of containers for arbitrary types (Vector, Set, Map, Deque, Stack, Queue, ...)
+  categories: data-types
+  tags: container template
+  license: Apache-2.0
+
+- name: gFTL-shared
+  github: Goddard-Fortran-Ecosystem/gFTL-shared
+  description: Instantiations of gFTL templates of common containers for intrinsic types
+  categories: data-types
+  tags: container template
+  license: Apache-2.0
+
 - name: PENF
   github: szaghi/PENF
   description: Provides portable kind-parameters and many useful procedures to deal with them
@@ -1540,20 +1554,6 @@
   description: Object-oriented Fortran falling block game using Curses console graphics
   categories: examples
   tags: game
-
-- name: gFTL
-  github: Goddard-Fortran-Ecosystem/gFTL
-  description: Templates for STL-like Fortran implementations of containers for arbitrary types (Vector, Set, Map, Deque, Stack, Queue, ...)
-  categories: programming
-  tags: container template
-  license: Apache-2.0
-
-- name: gFTL-shared
-  github: Goddard-Fortran-Ecosystem/gFTL-shared
-  description: Instantiations of gFTL templates of common containers for intrinsic types
-  categories: programming
-  tags: container template
-  license: Apache-2.0
 
 - name: yaFyaml
   github: Goddard-Fortran-Ecosystem/yaFyaml


### PR DESCRIPTION
The gFTL library is currently shown in the category "Error handling, logging, documentation and testing" but it is tagged as "container". It should be in the category "Libraries for advanced data types and container classes" along with the similar package Fortran template library (FTL).