### PR TITLE
Add FTorch to Package Index

### DIFF
--- a/data/package_index.yml
+++ b/data/package_index.yml
@@ -119,6 +119,14 @@
 
 # --- Interfaces ---
 
+- name: FTorch
+  github: Cambridge-ICCS/FTorch
+  description: Allows users to interface into the PyTorch machine learning library
+  categories: interfaces numerical scientific
+  tags:
+  license:
+  version: none
+
 - name: forpy
   github: ylikx/forpy
   description: allows you to use Python features in Fortran


### PR DESCRIPTION
We would like to add FTorch, a python library for directly interfacing from Fortran to PyTorch Machine Learning models, to the Fortran-Lang website.
This has been developed and deployed in a number of scientific codes.

I believe it meets the core requirements set out [here](https://fortran-lang.org/en/community/packages/#package-criteria).

The project is still being actively developed, but we are at a point where we feel it is of use to other developers.

The project is at https://github.com/Cambridge-ICCS/FTorch

There are some associated slides [here](https://jackatkinson.net/slides/RSECon23/RSECon23.html).

I couldn't fine a package PR template, but please do point me in the right direction if I missed it.

Thanks.