### PR TITLE
Add preCICE library to the package index

### DIFF
--- a/data/package_index.yml
+++ b/data/package_index.yml
@@ -297,6 +297,13 @@
   license: LGPL-3.0-or-later
   version: 1.3
 
+- name: preCICE
+  github: precice/precice
+  description: A coupling library for partitioned multi-physics simulations, including, but not restricted to fluid-structure interaction and conjugate heat transfer simulations.
+  categories: interfaces scientific
+  tags: cpp c python julia matlab rust mpi
+  license: LGPL-3.0
+
 # --- Compiler
 
 - name: hipfort


### PR DESCRIPTION
Adds [preCICE](https://precice.org/) to the categories `interfaces` and `scientific`.

preCICE is written in C++, but it has [bindings for Fortran and more languages](https://precice.org/couple-your-code-api.html).

Thanks to @ivan-pi for showing me this package index.