### PR TITLE
Use dev.lfortran.org for the playground for now

### DIFF
--- a/source/index.md
+++ b/source/index.md
@@ -147,7 +147,7 @@ Or just write Fortran software for your research, business, or schoolwork. You c
 :::{toctree}
 :hidden:
 
-Play <https://play.fortran-lang.org/>
+Play <https://dev.lfortran.org/>
 learn
 roadmap
 compilers

--- a/source/learn.md
+++ b/source/learn.md
@@ -79,7 +79,7 @@ Get a taste of Fortran in an interactive playground in the browser.
 
 ```{card}
 :link-type: url
-:link: https://play.fortran-lang.org/
+:link: https://dev.lfortran.org/
 :class-card: sd-btn
 :class-body: sd-p-1 sd-text-center sd-font-weight-bold sd-text-info sd-btn-primary sd-text-light sd-btn
 :shadow: none


### PR DESCRIPTION
This fixes the issue at https://fortran-lang.discourse.group/t/fortran-playground-broken-play-fortran-lang-org/7788.