### PR TITLE
Add athena entry to package index

### DIFF
--- a/data/package_index.yml
+++ b/data/package_index.yml
@@ -1079,7 +1079,14 @@
   description: A parallel multifrontal solver for sparse linear systems based on QR and Cholesky decomposition
   categories: numerical
   tags: QR Cholesky sparse multifrontal least-squares
-  
+
+- name: athena
+  github: nedtaylor/athena
+  description: A library for building, training and testing feed-forward neural networks.
+  categories: numerical
+  tags: machine-learning convolutional-neural-networks
+  license: MIT
+
 # --- Scientific codes ---
 
 - name: astro-fortran


### PR DESCRIPTION
Add [athena](https://github.com/nedtaylor/athena) to the `numerical` category.

I believe it conforms with all of the [package criteria](https://fortran-lang.org/community/packages/).

I was unable to find the 'Package index request' template mentioned on step 3 of the process for adding packages. If this is needed, please direct me to it and I will use that instead.