### PR TITLE
Add test-drive to the package index

### DIFF
--- a/data/package_index.yml
+++ b/data/package_index.yml
@@ -355,6 +355,14 @@
   tags: unit testing
   license: NASA-1.3
 
+- name: test-drive
+  github: https://github.com/fortran-lang/test-drive
+  description: The simple testing framework
+  categories: programming
+  tags: unit testing
+  version: 0.5.0
+  license: MIT AND Apache-2.0
+
 - name: erloff
   gitlab: everythingfunctional/erloff
   description: Errors and logging for fortran


### PR DESCRIPTION
This is one of the key fortran-lang projects but it is not properly referenced in the index https://github.com/fortran-lang/test-drive