### PR TITLE
Add Fortitude to the package index

### DIFF
--- a/data/package_index.yml
+++ b/data/package_index.yml
@@ -453,6 +453,13 @@
   categories: programming scientific
   tags: formatter compiler transformer
 
+- name: Fortitude
+  github: PlasmaFAIR/fortitude
+  description: A fast Ruff-like linting tool
+  categories: programming
+  license: MIT
+  tags: linter
+
 # --- Data types ---
 
 - name: Fortran template library


### PR DESCRIPTION
This PR adds [Fortitude](https://github.com/PlasmaFAIR/Fortitude) to the package index.

## Required

- Relevance: This is a Fortran linting tool, though is written in Rust. There are plans to add formatting functionality in the near-future.
- Maturity: Though fairly new, the repo has 70 stars and is still climbing in popularity.
- Availability: The source is freely available on GitHub.
- Open source: The package is licensed under MIT.
- Uniqueness: :white_check_mark: 
- README: States the purpose of the package, explains installation and usage, and links to more thorough documentation.

## Recommended

- Documentation: https://fortitude.readthedocs.io/en/stable/
- Contributing: https://github.com/PlasmaFAIR/fortitude/blob/main/CONTRIBUTING.md
- Tests: :white_check_mark: 

