### PR TITLE
Add raffle to the package index

### DIFF
--- a/data/package_index.yml
+++ b/data/package_index.yml
@@ -1556,6 +1556,13 @@
   tags: electronic-structure quantum-chemistry casscf
   license: Apache-2.0
 
+- name: raffle
+  github: ExeQuantCode/RAFFLE
+  description: Package for predicting material interface structures
+  categories: scientific
+  tags: material structure phase atomic molecular-modeling
+  license: GPL-3.0
+
 # --- Examples / demos / templates ---
 
 - name: Fortran 2018 examples


### PR DESCRIPTION
Add [RAFFLE](https://github.com/ExeQuantCode/RAFFLE) to the Scientific category.

I believe it conforms with all of the [package criteria](https://fortran-lang.org/community/packages/).