### PR TITLE
Fix Git repo for test-drive project

### DIFF
--- a/data/package_index.yml
+++ b/data/package_index.yml
@@ -356,7 +356,7 @@
   license: NASA-1.3
 
 - name: test-drive
-  github: https://github.com/fortran-lang/test-drive
+  github: fortran-lang/test-drive
   description: The simple testing framework
   categories: programming
   tags: unit testing


### PR DESCRIPTION
It looks like it should just be fortran-lang/test-drive, not https://github.com/fortran-lang/test-drive.

Fixes #536.