### PR TITLE
Fixed typos in object-based programming techniques

### DIFF
--- a/source/learn/oop_features_in_fortran/object_based_programming_techniques.md
+++ b/source/learn/oop_features_in_fortran/object_based_programming_techniques.md
@@ -152,9 +152,10 @@ to be aware of:
    is **opaque** (not a Fortran term), it can only be used if the type
    declaration is accessed by host association (this is the same as for
    nonallocatable/nonpointer components);
-2. especially for container-like types, its semantics may be
-   incompatible with the programmers intentions for how the objects
+2. Especially for container-like types, its semantics may be
+   incompatible with the programmer's intentions for how the objects
    should be used.
+
 
 Item 2 is illustrated by the above object setups, specifically:
 
@@ -479,7 +480,7 @@ case of polymorphic objects.
 ### Implementing move semantics
 
 Sometimes it may be necessary to make use of move instead of copy
-semantics i.e., create a copy of an object and then getting rid of the
+semantics i.e., create a copy of an object and then get rid of the 
 original. The simplest way of doing this is to make use of allocatable
 (scalar or array) objects,
 


### PR DESCRIPTION
### Title:
✅ _Fix typos and improve clarity in object-based programming techniques documentation_

### Description:
This pull request addresses minor grammatical errors and improves readability in the Object-Based Programming Techniques documentation.

### Changes:
Fixed grammatical inconsistency:

- **"programmers intentions" → "programmer's intentions"**
- **"create a copy of an object and then getting rid of the original" → "create a copy of an object and then get rid of the original"**
 ### Capitalization correction:

- **"especially" → "Especially"**
### Reason for Changes:

These updates ensure grammatical accuracy, better readability, and maintain a professional tone in the documentation.

### Checklist:

-  Grammar and spelling checked
-  Verified consistency in formatting
-  Ensured correctness of technical content