### PR TITLE
Add Geoschem to packages list

### DIFF
--- a/data/package_index.yml
+++ b/data/package_index.yml
@@ -1575,6 +1575,13 @@
   tags: material structure phase atomic molecular-modeling
   license: GPL-3.0
 
+- name: GEOS-Chem
+  github: geoschem/geos-chem
+  description: Atmospheric chemistry model 
+  categories: scientific
+  tags: climate chemistry atmospheric-modelling atmospheric-chemistry 
+  license: MIT
+
 # --- Examples / demos / templates ---
 
 - name: Fortran 2018 examples


### PR DESCRIPTION
Add package [geoschem](https://github.com/geoschem) to the packages list

Fulfils criteria: 
## Required
 - Relevance - Climate modelling software in use by many research groups
 - Maturity - in development since at least 2007 , 176 github stars, 100+ publications found with google scholar
 - Availability - via github
 - Open source - MIT license
 - Uniqueness - this is the source code from the geoschem team
 - README - Exists, describes, links to further docs.  
## Recommended 
- Documentation -  More documentation on its web pages https://geos-chem.readthedocs.io/en/stable/ : Contributing guidelines , examples 