### PR TITLE
Add fiats to the package index

### DIFF
--- a/data/package_index.yml
+++ b/data/package_index.yml
@@ -864,6 +864,12 @@
   tags: back propagation coarray
   version: none
 
+- name: fiats
+  github: BerkeleyLab/fiats
+  description: A deep learning library for use in high-performance computing applications in modern Fortran
+  categories: numerical
+  tags: machine-learning
+
 - name: ParaMonte
   github: cdslaborg/paramonte
   description: A general-purpose high-performance MPI/Coarray-parallel Monte Carlo simulation library implemented in Fortran 2018 with interfaces to C/C++/Fortran/MATLAB/Python


### PR DESCRIPTION
This PR adds [fiats](https://github.com/BerkeleyLab/fiats) to the package index.

## Required

* Relevance - this is a deep learning library for use in high-performance computing applications in modern Fortran. 
* Maturity - the repo is approaching maturity and has 42 stars.
* Availability - the source is freely available on GitHub.
* Open source - the package is licensed under a US Department of Energy license.
* Uniqueness - this is an original repo, not a fork.
* README - this exists, clearly states the purpose, and contains detailed information on how to install under different compilers, as well as a link to the GitHub Pages, which contains more detailed information on usage.

## Recommended

* Documentation - https://berkeleylab.github.io/fiats/
* Tests - reasonable test suite