### PR TITLE
Add setup-fortran to package index

### DIFF
--- a/data/package_index.yml
+++ b/data/package_index.yml
@@ -362,6 +362,12 @@
   version: 0.5.0
   license: MIT AND Apache-2.0
 
+- name: setup-fortran
+  github: fortran-lang/setup-fortran
+  description: GitHub action to setup Fortran compiler and toolchain
+  categories: programming
+  tags: continuous-integration
+
 - name: erloff
   gitlab: everythingfunctional/erloff
   description: Errors and logging for fortran


### PR DESCRIPTION
This PR adds [setup-fortran](https://github.com/fortran-lang/setup-fortran) to the package index. I was surprised it wasn't already in there.

* Relevance - this is a GitHub action to setup Fortran compiler and toolchain. 
* Maturity - the repo is mature and has 85 stars.
* Availability - the source is freely available on GitHub.
* Open source - the package is licensed under Apache License version 2.0.
* Uniqueness - this is an original repo, not a fork.
* README - this exists, provides information on usage and configuration options.