### PR TITLE
Add Differentia package to index

### DIFF
--- a/data/package_index.yml
+++ b/data/package_index.yml
@@ -394,7 +394,7 @@
   github: Nicholaswogan/Differentia
   description: Computes derivatives, gradients and Jacobians of Fortran functions/subroutines using forward automatic differentiation.
   categories: programming numerical
-  tags: algorithmic derivative ad
+  tags: algorithmic derivative AD autodiff
   license: MIT
   version: 0.1.4
 

--- a/data/package_index.yml
+++ b/data/package_index.yml
@@ -390,6 +390,14 @@
   license: MIT
   version: 3.16-v2
 
+- name: Differentia
+  github: Nicholaswogan/Differentia
+  description: Computes derivatives, gradients and Jacobians of Fortran functions/subroutines using forward automatic differentiation.
+  categories: programming numerical
+  tags: algorithmic derivative ad
+  license: MIT
+  version: 0.1.4
+
 - name: camfort
   github: camfort/camfort
   description: Light-weight verification and transformation tools for Fortran


### PR DESCRIPTION
This PR adds https://github.com/Nicholaswogan/Differentia to the package index.

## Required
- Relevance - This is a package allowing for derivatives, gradients and Jacobians of Fortran functions/subroutines to be calculated using Forward Automatic Differentiation
- Maturity - the code is stable and the repo is actively developed.
Availability - the source is freely available on GitHub.
- Open source - the package is licensed under MIT License.
- Uniqueness - this is an original repo, not a fork.
- README - this exists, clearly states the purpose, and contains information on the steps required to install, as well as a link to build the code and run the tests
## Recommended
- Tests: the code is well tested, with tests being easy to run
- FPM: supports installation via [fpm](https://github.com/fortran-lang/fpm) via `fpm.toml`
