### PR TITLE
Update 'learn' page

### DIFF
--- a/data/learning.yml
+++ b/data/learning.yml
@@ -326,9 +326,6 @@ reference-courses:
     description: >-
       course offered at the Leibniz-Rechenzentrum
 
-  - name: "PRACE Course: Fortran for Scientific Computing"
-    url: https://www.futurelearn.com/courses/fortran-for-scientific-computing
-
   - name: "PRACE Course: Advanced Fortran Topics"
     url: https://doku.lrz.de/display/PUBLIC/PRACE+Course%3A+Advanced+Fortran+Topics
 
@@ -336,11 +333,6 @@ reference-courses:
     url: https://www.youtube.com/playlist?list=PLRO4xf5MdhAv9CNTETor75rANZtBqPVgQ
     description: >-
       modern Fortran for developing an extensible library that can be used to solve conservation laws (PDEs) using spectral and spectral element methods
-
-  - name: "Kursmaterial für Wissenschaftliches Programmieren (Modern Fortran, 2017)"
-    url: https://www.bccms.uni-bremen.de/cms/people/b-aradi/wissen-progr/modern-fortran/2017
-    description: >-
-      from Bálint Aradi at Bremen Center for Computational Materials Science (German)
 
   - name: "Formations Fortran"
     url: http://www.idris.fr/formations/fortran/
@@ -370,16 +362,8 @@ reference-courses:
     description: >-
       by Philipp Engel
 
-  - name: "2018 Workshop on Fortran Modernization for Scientific Applications"
-    url: https://tcevents.chem.uzh.ch/event/3/
-
   - name: "Introduction to Programming using Fortran 95/2003/2008"
     url: http://www.egr.unlv.edu/~ed/fortran.html
-
-  - name: "Scientific Programing and Numerical Computation"
-    url: http://homepage.ntu.edu.tw/~wttsai/fortran/
-    description: >-
-      course by Wu-ting Tsai from National Taiwan University
 
   - name: "Introduction to Modern Fortran"
     url: https://www-uxsup.csx.cam.ac.uk/courses/moved.Fortran/
@@ -402,30 +386,10 @@ reference-courses:
     description: >-
       course by Anton Shterenlikht from the University of Bristol
 
-  - name: "Professional Programmer's Guide to Fortran77"
-    url: https://www.star.le.ac.uk/~cgp/prof77.html
-    description: >-
-      by Clive G. Page, University of Leicester, UK
-
-  - name: "Fortran90 for Fortran77 Programmers"
-    url: https://www.star.le.ac.uk/~cgp/f90course/f90.html
-    description: >-
-      by Clive G. Page
-
-  - name: "Introduction to Computer Programming Using Fortran 95"
-    url: https://www.archer.ac.uk/training/course-material/2014/08/F95_CCFE/Fortran95CourseNotes.pdf
-    description: >-
-      training materials from ARCHER, the UK National Supercomputing Service
-
   - name: "Combining Object-Oriented Techniques with Co-arrays in Fortran 2008"
     url: https://www.ecmwf.int/sites/default/files/elibrary/2008/15361-combining-object-oriented-techniques-co-arrays-fortran.pdf
     description: >-
       by Robert W. Numrich
-
-  - name: "Parallel programming in Fortran with Coarrays"
-    url: ftp://ftp.numerical.rl.ac.uk/pub/talks/jkr.reading.5XI08.pdf
-    description: >-
-      by John Reid
 
   - name: "Introduction to Co-Array Fortran"
     url: https://faculty.csbsju.edu/mheroux/fall2011_csci317/NumrichCafTalk.pdf
@@ -437,20 +401,10 @@ reference-courses:
     description: >-
       by Bo Einarsson and Yurij Shokin
 
-  - name: "Fortran Tutorial"
-    url: https://www.tat.physik.uni-tuebingen.de/~kley/lehre/ftn77/tutorial/
-    description: >-
-      older tutorial by Erik Boman, Stanford University
-
   - name: "Fortran 90 Tutorial"
     url: https://web.stanford.edu/class/me200c/tutorial_90/
     description: >-
       older tutorial by Paul Hargrove and Sarah Whitlock, Stanford University
-
-  - name: "Fortran 90 Tutorial"
-    url: https://pages.mtu.edu/%7eshene/COURSES/cs201/NOTES/fortran.html
-    description: >-
-      by C.-K. Shene, Michigan Technologial University
 
   - name: "Exploring Modern Fortran Basics"
     url: https://www.manning.com/books/exploring-modern-fortran-basics

--- a/data/learning.yml
+++ b/data/learning.yml
@@ -349,38 +349,64 @@ reference-courses:
   - name: "Programming in Fortran"
     url: https://doku.lrz.de/display/PUBLIC/Programming+with+Fortran
     description: >-
-      course offered at the Leibniz-Rechenzentrum
+      course offered at the Leibniz-Rechenzentrum (slides, sample code)
 
   - name: "PRACE Course: Advanced Fortran Topics"
-    url: https://doku.lrz.de/display/PUBLIC/PRACE+Course%3A+Advanced+Fortran+Topics
+    url: https://doku.lrz.de/display/PUBLIC/PRACE+Course%3A+Advanced+Fortran+Topics 
+    description: >-
+      (slides, sample code)
 
   - name: "The 'F' Word - Programming in Fortran"
     url: https://www.youtube.com/playlist?list=PLRO4xf5MdhAv9CNTETor75rANZtBqPVgQ
     description: >-
-      modern Fortran for developing an extensible library that can be used to solve conservation laws (PDEs) using spectral and spectral element methods
+      modern Fortran for developing an extensible library that can be used to solve conservation laws (PDEs) using spectral and spectral element methods (video)
+
+  - name: "Introduction to modern Fortran"
+    url: https://www.youtube.com/playlist?list=PLB4tvLCynFjRJchIJjKiGGhW4rI5kbmql
+    description: >- 
+      Modern Fortran course delivered by Edinburgh Parallel Computing Centre (video)
 
   - name: "Formations Fortran"
     url: http://www.idris.fr/formations/fortran/
     description: >-
-      Fortran course from beginner to expert level (French)
+      Fortran course from beginner to expert level (French) (slides, sample code)
 
   - name: "Modern Fortran Programming for Chemists and Physicists"
     url: http://www.chem.helsinki.fi/~manninen/fortran2014/
     description: >-
-      course by Pekka Manninen from University of Helsinki (includes coarrays)
+      course by Pekka Manninen from University of Helsinki (includes coarrays) (slides, sample code)
 
   - name: "Expressing Object-Oriented Concepts in Fortran90"
-    url: http://www.cs.rpi.edu/~szymansk/OOF90/Forum.html
+    url: http://www.cs.rpi.edu/~szymansk/OOF90/Forum.html 
+    description: >-
+      (course notes, sample code)
 
   - name: "Coarray tutorial"
     url: https://github.com/tkoenig1/coarray-tutorial/blob/main/tutorial.md
     description: >-
-      by Thomas Koenig
+      by Thomas Koenig (course notes, sample code)
 
-  - name: "Parallel Programming Workshop"
-    url: https://fs.hlrs.de/projects/par/par_prog_ws/
+  - name: "Introduction to Modern Fortran"
+    url: https://www-uxsup.csx.cam.ac.uk/courses/moved.Fortran/
     description: >-
-      materials from the High-Performance Computing Center in Stuttgart
+      course given by Nick Maclaren from the University of Cambridge Computing Service,
+      derived from a course by Steve Morgan from the University of Liverpool (slides, sample code)
+
+  - name: "Combining Object-Oriented Techniques with Co-arrays in Fortran 2008"
+    url: https://www.ecmwf.int/sites/default/files/elibrary/2008/15361-combining-object-oriented-techniques-co-arrays-fortran.pdf
+    description: >-
+      by Robert W. Numrich (slides)
+
+  - name: "Introduction to Co-Array Fortran"
+    url: https://faculty.csbsju.edu/mheroux/fall2011_csci317/NumrichCafTalk.pdf
+    description: >-
+      by Robert W. Numrich (slides)
+
+reference-ebooks:
+  - name: "Exploring Modern Fortran Basics"
+    url: https://www.manning.com/books/exploring-modern-fortran-basics
+    description: >-
+      by Milan Curcic, excerpt (Chapters 2, 3, and 4) from Modern Fortran - Building Efficient Parallel Applications
 
   - name: "Programming in Modern Fortran"
     url: https://cyber.dabamos.de/programming/modernfortran/
@@ -388,16 +414,14 @@ reference-courses:
       by Philipp Engel
 
   - name: "Introduction to Programming using Fortran 95/2003/2008"
-    url: http://www.egr.unlv.edu/~ed/fortran.html
-
-  - name: "Introduction to Modern Fortran"
-    url: https://www-uxsup.csx.cam.ac.uk/courses/moved.Fortran/
-    description: >-
-      course given by Nick Maclaren from the University of Cambridge Computing Service,
-      derived from a course by Steve Morgan from the University of Liverpool
+    url: http://www.egr.unlv.edu/~ed/fortran.html 
+    description: >- 
+      by Ed Jorgensen
 
   - name: "User Notes on Fortran Programming (UNFP)"
-    url: http://www.ibiblio.org/pub/languages/fortran/unfp.html
+    url: http://www.ibiblio.org/pub/languages/fortran/unfp.html 
+    description: >-
+     
 
   - name: "Designing and Building Parallel Programs"
     url: https://www.mcs.anl.gov/~itf/dbpp/
@@ -411,16 +435,6 @@ reference-courses:
     description: >-
       course by Anton Shterenlikht from the University of Bristol
 
-  - name: "Combining Object-Oriented Techniques with Co-arrays in Fortran 2008"
-    url: https://www.ecmwf.int/sites/default/files/elibrary/2008/15361-combining-object-oriented-techniques-co-arrays-fortran.pdf
-    description: >-
-      by Robert W. Numrich
-
-  - name: "Introduction to Co-Array Fortran"
-    url: https://faculty.csbsju.edu/mheroux/fall2011_csci317/NumrichCafTalk.pdf
-    description: >-
-      by Robert W. Numrich
-
   - name: "Fortran 90 for the Fortran 77 Programmer"
     url: https://www.nsc.liu.se/~boein/f77to90/f77to90.html
     description: >-
@@ -430,12 +444,6 @@ reference-courses:
     url: https://web.stanford.edu/class/me200c/tutorial_90/
     description: >-
       older tutorial by Paul Hargrove and Sarah Whitlock, Stanford University
-
-  - name: "Exploring Modern Fortran Basics"
-    url: https://www.manning.com/books/exploring-modern-fortran-basics
-    description: >-
-      by Milan Curcic, excerpt (Chapters 2, 3, and 4) from Modern Fortran - Building Efficient Parallel Applications
-
 # Print books listed at the bottom of the 'Learn' landing page
 #
 #  Note: urls are publisher's site or DOI link

--- a/data/learning.yml
+++ b/data/learning.yml
@@ -343,7 +343,7 @@ reference-course-providers:
 
   - name: "Intel"
     url: https://www.intel.com/content/www/us/en/developer/tools/oneapi/tech-articles-how-to/library.html
-    description: collection of on-demand training and articles.
+    description: Collection of on-demand training and articles.
 
 reference-courses:
   - name: "Programming in Fortran"

--- a/data/learning.yml
+++ b/data/learning.yml
@@ -320,6 +320,31 @@ reference-links:
     url: https://stevelionel.com/drfortran
     description: A collection of posts on interesting or little-understood aspects of the Fortran language
 
+reference-course-providers:
+  - name: "ARCHER2 service training UK"
+    url: https://www.archer2.ac.uk/training/#upcoming-training
+    description: In-person/online courses in the UK on Fortran and related topics. 
+
+  - name: "High Performance Computing Centre Stuttgart"
+    url: https://www.hlrs.de/training/hpc-training
+    description: In-person/online courses in Germany on Fortran and HPC 
+
+  - name: "National Energy Research Scientific Computing Center (NERSC)"
+    url: https://www.nersc.gov/users/training/training-materials/
+    description: In-person/online courses in USA on Fortran and HPC
+
+  - name: "National Center for Atmospheric Research"
+    url: https://www.mmm.ucar.edu/events/tutorials
+    description: Training on using atmospheric modelling packages 
+
+  - name: "NASA"
+    url: https://astg.pages.smce.nasa.gov/website/fortran/
+    description: Courses on the use of Fortran for scientific computing
+
+  - name: "Intel"
+    url: https://www.intel.com/content/www/us/en/developer/tools/oneapi/tech-articles-how-to/library.html
+    description: collection of on-demand training and articles.
+
 reference-courses:
   - name: "Programming in Fortran"
     url: https://doku.lrz.de/display/PUBLIC/Programming+with+Fortran

--- a/fortran_package.py
+++ b/fortran_package.py
@@ -55,6 +55,7 @@ conf["reference_books"] = conf["reference-books"]
 conf["reference_courses"] = conf["reference-courses"]
 conf["reference_links"] = conf["reference-links"]
 conf["reference_course_providers"] = conf["reference-course-providers"]
+conf["reference_ebooks"] = conf["reference-ebooks"]
 
 with open(root / "_data" / "fortran_package.json", "w") as f:
     json.dump(fortran_tags, f)

--- a/fortran_package.py
+++ b/fortran_package.py
@@ -54,6 +54,7 @@ fortran_tags["data_types"] = fortran_tags.pop("data-types")
 conf["reference_books"] = conf["reference-books"]
 conf["reference_courses"] = conf["reference-courses"]
 conf["reference_links"] = conf["reference-links"]
+conf["reference_course_providers"] = conf["reference-course-providers"]
 
 with open(root / "_data" / "fortran_package.json", "w") as f:
     json.dump(fortran_tags, f)

--- a/source/learn.md
+++ b/source/learn.md
@@ -145,7 +145,7 @@ On the web
 
 :::{div} sd-fs-4 sd-font-weight-bold sd-text-primary
 
-Online Courses
+Online Training Materials
 :::
 
 :::{jinja} conf

--- a/source/learn.md
+++ b/source/learn.md
@@ -145,6 +145,21 @@ On the web
 
 :::{div} sd-fs-4 sd-font-weight-bold sd-text-primary
 
+Training providers
+:::
+
+:::{jinja} conf
+
+{% for course in reference_course_providers %}
+
+- [{{course.name}}]({{course.url}}) {{course.description}}
+
+{% endfor %}
+:::
+
+:::{div} sd-fs-4 sd-font-weight-bold sd-text-primary
+
+
 Online Training Materials
 :::
 

--- a/source/learn.md
+++ b/source/learn.md
@@ -160,7 +160,7 @@ Training providers
 :::{div} sd-fs-4 sd-font-weight-bold sd-text-primary
 
 
-Online Training Materials
+Online Course Materials
 :::
 
 :::{jinja} conf
@@ -174,6 +174,19 @@ Online Training Materials
 
 :::{div} sd-fs-4 sd-font-weight-bold sd-text-primary
 
+E-books
+:::
+
+:::{jinja} conf
+
+{% for course in reference_ebooks %}
+
+- [{{course.name}}]({{course.url}}) {{course.description}}
+
+{% endfor %}
+:::
+
+:::{div} sd-fs-4 sd-font-weight-bold sd-text-primary
 In print
 :::
 


### PR DESCRIPTION
Several updates to the 'learn' page

1. Several of the links in the 'online courses' section were dead. They have been removed
2. A new category 'training providers' has been added, linking to places where in-person/remote courses are advertised. 
3. Existing links to 'online courses' have been split. Several constitute ebooks, so a new heading is added for those. The others now contain in the description a 'type', e.g. (video), (sample code), (course slides).

Depending on whether the [policy for including commercial _packages_](https://fortran-lang.discourse.group/t/commercial-packages-referenced-by-fortran-lang-org/9554/2) is changed, it may be appropriate to add in some additional training providers. 