### PR TITLE
Display package license info if provided in `package_index.yml`

### DIFF
--- a/source/packages/data-types.md
+++ b/source/packages/data-types.md
@@ -16,7 +16,11 @@ A rich ecosystem of high-performance code
 
 ## {fab}`github;1em` [{{j.name}}]({{"https://github.com/"+j.github}})
 <img src="{{'https://img.shields.io/github/v/release/'+j.github+'?color=green'}}" alt="Release">
+{% if j.license is defined %}
+<img src='https://img.shields.io/badge/license-{{ j.license | replace("-", "--") | replace("_", "__") }}-blue' alt="license">
+{% else %}
 <img src="{{'https://img.shields.io/github/license/'+j.github}}" alt="license">
+{% endif %}
 <img src="{{'https://img.shields.io/github/stars/'+j.github}}" alt="stars">
 <img src="{{'https://img.shields.io/github/forks/'+j.github}}" alt="forks">
 <img src="{{'https://img.shields.io/github/last-commit/'+j.github+'?color=blue'}}" alt="last-commit">
@@ -34,7 +38,11 @@ Tags: {% for tag in j.tags.split() %} {bdg-light}`{{ tag }}` {% endfor %}
 ## {fab}`gitlab;1em` [{{j.name}}]({{"https://gitlab.com/"+j.gitlab}})
 
 <img src="{{'https://img.shields.io/gitlab/v/release/'+j.gitlab+'?date_order_by=created_at&sort=date&color=green'}}" alt="Release">
+{% if j.license is defined %}
+<img src='https://img.shields.io/badge/license-{{ j.license | replace("-", "--") | replace("_", "__") }}-blue' alt="license">
+{% else %}
 <img src="{{'https://img.shields.io/gitlab/license/'+j.gitlab}}" alt="license">
+{% endif %}
 <img src="{{'https://img.shields.io/gitlab/forks/'+j.gitlab}}" alt="forks">
 <img src="{{'https://img.shields.io/gitlab/issues/all/'+j.gitlab+'?color=yellow'}}" alt="issues">
 {% if j.description is defined %}
@@ -48,6 +56,9 @@ Tags: {% for tag in j.tags.split() %} {bdg-light}`{{ tag }}` {% endfor %}
 
 ## {fab}`git-alt;1em` [{{j.name}}]({{j.url}})
 
+{% if j.license is defined %}
+<img src='https://img.shields.io/badge/license-{{ j.license | replace("-", "--") | replace("_", "__") }}-blue' alt="license">
+{% endif %}
 {% if j.description is defined %}
 {{j.description}}
 {% endif %}

--- a/source/packages/examples.md
+++ b/source/packages/examples.md
@@ -17,7 +17,11 @@ A rich ecosystem of high-performance code
 
 ## {fab}`github;1em` [{{j.name}}]({{"https://github.com/"+j.github}})
 <img src="{{'https://img.shields.io/github/v/release/'+j.github+'?color=green'}}" alt="Release">
+{% if j.license is defined %}
+<img src='https://img.shields.io/badge/license-{{ j.license | replace("-", "--") | replace("_", "__") }}-blue' alt="license">
+{% else %}
 <img src="{{'https://img.shields.io/github/license/'+j.github}}" alt="license">
+{% endif %}
 <img src="{{'https://img.shields.io/github/stars/'+j.github}}" alt="stars">
 <img src="{{'https://img.shields.io/github/forks/'+j.github}}" alt="forks">
 <img src="{{'https://img.shields.io/github/last-commit/'+j.github+'?color=blue'}}" alt="last-commit">
@@ -35,7 +39,11 @@ Tags: {% for tag in j.tags.split() %} {bdg-light}`{{ tag }}` {% endfor %}
 ## {fab}`gitlab;1em` [{{j.name}}]({{"https://gitlab.com/"+j.gitlab}})
 
 <img src="{{'https://img.shields.io/gitlab/v/release/'+j.gitlab+'?date_order_by=created_at&sort=date&color=green'}}" alt="Release">
+{% if j.license is defined %}
+<img src='https://img.shields.io/badge/license-{{ j.license | replace("-", "--") | replace("_", "__") }}-blue' alt="license">
+{% else %}
 <img src="{{'https://img.shields.io/gitlab/license/'+j.gitlab}}" alt="license">
+{% endif %}
 <img src="{{'https://img.shields.io/gitlab/forks/'+j.gitlab}}" alt="forks">
 <img src="{{'https://img.shields.io/gitlab/issues/all/'+j.gitlab+'?color=yellow'}}" alt="issues">
 {% if j.description is defined %}
@@ -49,6 +57,9 @@ Tags: {% for tag in j.tags.split() %} {bdg-light}`{{ tag }}` {% endfor %}
 
 ## {fab}`git-alt;1em` [{{j.name}}]({{j.url}})
 
+{% if j.license is defined %}
+<img src='https://img.shields.io/badge/license-{{ j.license | replace("-", "--") | replace("_", "__") }}-blue' alt="license">
+{% endif %}
 {% if j.description is defined %}
 {{j.description}}
 {% endif %}

--- a/source/packages/graphics.md
+++ b/source/packages/graphics.md
@@ -16,7 +16,11 @@ A rich ecosystem of high-performance code
 
 ## {fab}`github;1em` [{{j.name}}]({{"https://github.com/"+j.github}})
 <img src="{{'https://img.shields.io/github/v/release/'+j.github+'?color=green'}}" alt="Release">
+{% if j.license is defined %}
+<img src='https://img.shields.io/badge/license-{{ j.license | replace("-", "--") | replace("_", "__") }}-blue' alt="license">
+{% else %}
 <img src="{{'https://img.shields.io/github/license/'+j.github}}" alt="license">
+{% endif %}
 <img src="{{'https://img.shields.io/github/stars/'+j.github}}" alt="stars">
 <img src="{{'https://img.shields.io/github/forks/'+j.github}}" alt="forks">
 <img src="{{'https://img.shields.io/github/last-commit/'+j.github+'?color=blue'}}" alt="last-commit">
@@ -34,7 +38,11 @@ Tags: {% for tag in j.tags.split() %} {bdg-light}`{{ tag }}` {% endfor %}
 ## {fab}`gitlab;1em` [{{j.name}}]({{"https://gitlab.com/"+j.gitlab}})
 
 <img src="{{'https://img.shields.io/gitlab/v/release/'+j.gitlab+'?date_order_by=created_at&sort=date&color=green'}}" alt="Release">
+{% if j.license is defined %}
+<img src='https://img.shields.io/badge/license-{{ j.license | replace("-", "--") | replace("_", "__") }}-blue' alt="license">
+{% else %}
 <img src="{{'https://img.shields.io/gitlab/license/'+j.gitlab}}" alt="license">
+{% endif %}
 <img src="{{'https://img.shields.io/gitlab/forks/'+j.gitlab}}" alt="forks">
 <img src="{{'https://img.shields.io/gitlab/issues/all/'+j.gitlab+'?color=yellow'}}" alt="issues">
 {% if j.description is defined %}
@@ -48,6 +56,9 @@ Tags: {% for tag in j.tags.split() %} {bdg-light}`{{ tag }}` {% endfor %}
 
 ## {fab}`git-alt;1em` [{{j.name}}]({{j.url}})
 
+{% if j.license is defined %}
+<img src='https://img.shields.io/badge/license-{{ j.license | replace("-", "--") | replace("_", "__") }}-blue' alt="license">
+{% endif %}
 {% if j.description is defined %}
 {{j.description}}
 {% endif %}

--- a/source/packages/interfaces.md
+++ b/source/packages/interfaces.md
@@ -16,7 +16,11 @@ A rich ecosystem of high-performance code
 
 ## {fab}`github;1em` [{{j.name}}]({{"https://github.com/"+j.github}})
 <img src="{{'https://img.shields.io/github/v/release/'+j.github+'?color=green'}}" alt="Release">
+{% if j.license is defined %}
+<img src='https://img.shields.io/badge/license-{{ j.license | replace("-", "--") | replace("_", "__") }}-blue' alt="license">
+{% else %}
 <img src="{{'https://img.shields.io/github/license/'+j.github}}" alt="license">
+{% endif %}
 <img src="{{'https://img.shields.io/github/stars/'+j.github}}" alt="stars">
 <img src="{{'https://img.shields.io/github/forks/'+j.github}}" alt="forks">
 <img src="{{'https://img.shields.io/github/last-commit/'+j.github+'?color=blue'}}" alt="last-commit">
@@ -34,7 +38,11 @@ Tags: {% for tag in j.tags.split() %} {bdg-light}`{{ tag }}` {% endfor %}
 ## {fab}`gitlab;1em` [{{j.name}}]({{"https://gitlab.com/"+j.gitlab}})
 
 <img src="{{'https://img.shields.io/gitlab/v/release/'+j.gitlab+'?date_order_by=created_at&sort=date&color=green'}}" alt="Release">
+{% if j.license is defined %}
+<img src='https://img.shields.io/badge/license-{{ j.license | replace("-", "--") | replace("_", "__") }}-blue' alt="license">
+{% else %}
 <img src="{{'https://img.shields.io/gitlab/license/'+j.gitlab}}" alt="license">
+{% endif %}
 <img src="{{'https://img.shields.io/gitlab/forks/'+j.gitlab}}" alt="forks">
 <img src="{{'https://img.shields.io/gitlab/issues/all/'+j.gitlab+'?color=yellow'}}" alt="issues">
 {% if j.description is defined %}
@@ -48,6 +56,9 @@ Tags: {% for tag in j.tags.split() %} {bdg-light}`{{ tag }}` {% endfor %}
 
 ## {fab}`git-alt;1em` [{{j.name}}]({{j.url}})
 
+{% if j.license is defined %}
+<img src='https://img.shields.io/badge/license-{{ j.license | replace("-", "--") | replace("_", "__") }}-blue' alt="license">
+{% endif %}
 {% if j.description is defined %}
 {{j.description}}
 {% endif %}

--- a/source/packages/io.md
+++ b/source/packages/io.md
@@ -16,7 +16,11 @@ A rich ecosystem of high-performance code
 
 ## {fab}`github;1em` [{{j.name}}]({{"https://github.com/"+j.github}})
 <img src="{{'https://img.shields.io/github/v/release/'+j.github+'?color=green'}}" alt="Release">
+{% if j.license is defined %}
+<img src='https://img.shields.io/badge/license-{{ j.license | replace("-", "--") | replace("_", "__") }}-blue' alt="license">
+{% else %}
 <img src="{{'https://img.shields.io/github/license/'+j.github}}" alt="license">
+{% endif %}
 <img src="{{'https://img.shields.io/github/stars/'+j.github}}" alt="stars">
 <img src="{{'https://img.shields.io/github/forks/'+j.github}}" alt="forks">
 <img src="{{'https://img.shields.io/github/last-commit/'+j.github+'?color=blue'}}" alt="last-commit">
@@ -34,7 +38,11 @@ Tags: {% for tag in j.tags.split() %} {bdg-light}`{{ tag }}` {% endfor %}
 ## {fab}`gitlab;1em` [{{j.name}}]({{"https://gitlab.com/"+j.gitlab}})
 
 <img src="{{'https://img.shields.io/gitlab/v/release/'+j.gitlab+'?date_order_by=created_at&sort=date&color=green'}}" alt="Release">
+{% if j.license is defined %}
+<img src='https://img.shields.io/badge/license-{{ j.license | replace("-", "--") | replace("_", "__") }}-blue' alt="license">
+{% else %}
 <img src="{{'https://img.shields.io/gitlab/license/'+j.gitlab}}" alt="license">
+{% endif %}
 <img src="{{'https://img.shields.io/gitlab/forks/'+j.gitlab}}" alt="forks">
 <img src="{{'https://img.shields.io/gitlab/issues/all/'+j.gitlab+'?color=yellow'}}" alt="issues">
 {% if j.description is defined %}
@@ -48,6 +56,9 @@ Tags: {% for tag in j.tags.split() %} {bdg-light}`{{ tag }}` {% endfor %}
 
 ## {fab}`git-alt;1em` [{{j.name}}]({{j.url}})
 
+{% if j.license is defined %}
+<img src='https://img.shields.io/badge/license-{{ j.license | replace("-", "--") | replace("_", "__") }}-blue' alt="license">
+{% endif %}
 {% if j.description is defined %}
 {{j.description}}
 {% endif %}

--- a/source/packages/libraries.md
+++ b/source/packages/libraries.md
@@ -16,7 +16,11 @@ A rich ecosystem of high-performance code
 
 ## {fab}`github;1em` [{{j.name}}]({{"https://github.com/"+j.github}})
 <img src="{{'https://img.shields.io/github/v/release/'+j.github+'?color=green'}}" alt="Release">
+{% if j.license is defined %}
+<img src='https://img.shields.io/badge/license-{{ j.license | replace("-", "--") | replace("_", "__") }}-blue' alt="license">
+{% else %}
 <img src="{{'https://img.shields.io/github/license/'+j.github}}" alt="license">
+{% endif %}
 <img src="{{'https://img.shields.io/github/stars/'+j.github}}" alt="stars">
 <img src="{{'https://img.shields.io/github/forks/'+j.github}}" alt="forks">
 <img src="{{'https://img.shields.io/github/last-commit/'+j.github+'?color=blue'}}" alt="last-commit">
@@ -34,7 +38,11 @@ Tags: {% for tag in j.tags.split() %} {bdg-light}`{{ tag }}` {% endfor %}
 ## {fab}`gitlab;1em` [{{j.name}}]({{"https://gitlab.com/"+j.gitlab}})
 
 <img src="{{'https://img.shields.io/gitlab/v/release/'+j.gitlab+'?date_order_by=created_at&sort=date&color=green'}}" alt="Release">
+{% if j.license is defined %}
+<img src='https://img.shields.io/badge/license-{{ j.license | replace("-", "--") | replace("_", "__") }}-blue' alt="license">
+{% else %}
 <img src="{{'https://img.shields.io/gitlab/license/'+j.gitlab}}" alt="license">
+{% endif %}
 <img src="{{'https://img.shields.io/gitlab/forks/'+j.gitlab}}" alt="forks">
 <img src="{{'https://img.shields.io/gitlab/issues/all/'+j.gitlab+'?color=yellow'}}" alt="issues">
 {% if j.description is defined %}
@@ -48,6 +56,9 @@ Tags: {% for tag in j.tags.split() %} {bdg-light}`{{ tag }}` {% endfor %}
 
 ## {fab}`git-alt;1em` [{{j.name}}]({{j.url}})
 
+{% if j.license is defined %}
+<img src='https://img.shields.io/badge/license-{{ j.license | replace("-", "--") | replace("_", "__") }}-blue' alt="license">
+{% endif %}
 {% if j.description is defined %}
 {{j.description}}
 {% endif %}

--- a/source/packages/numerical.md
+++ b/source/packages/numerical.md
@@ -16,7 +16,11 @@ A rich ecosystem of high-performance code
 
 ## {fab}`github;1em` [{{j.name}}]({{"https://github.com/"+j.github}})
 <img src="{{'https://img.shields.io/github/v/release/'+j.github+'?color=green'}}" alt="Release">
+{% if j.license is defined %}
+<img src='https://img.shields.io/badge/license-{{ j.license | replace("-", "--") | replace("_", "__") }}-blue' alt="license">
+{% else %}
 <img src="{{'https://img.shields.io/github/license/'+j.github}}" alt="license">
+{% endif %}
 <img src="{{'https://img.shields.io/github/stars/'+j.github}}" alt="stars">
 <img src="{{'https://img.shields.io/github/forks/'+j.github}}" alt="forks">
 <img src="{{'https://img.shields.io/github/last-commit/'+j.github+'?color=blue'}}" alt="last-commit">
@@ -34,7 +38,11 @@ Tags: {% for tag in j.tags.split() %} {bdg-light}`{{ tag }}` {% endfor %}
 ## {fab}`gitlab;1em` [{{j.name}}]({{"https://gitlab.com/"+j.gitlab}})
 
 <img src="{{'https://img.shields.io/gitlab/v/release/'+j.gitlab+'?date_order_by=created_at&sort=date&color=green'}}" alt="Release">
+{% if j.license is defined %}
+<img src='https://img.shields.io/badge/license-{{ j.license | replace("-", "--") | replace("_", "__") }}-blue' alt="license">
+{% else %}
 <img src="{{'https://img.shields.io/gitlab/license/'+j.gitlab}}" alt="license">
+{% endif %}
 <img src="{{'https://img.shields.io/gitlab/forks/'+j.gitlab}}" alt="forks">
 <img src="{{'https://img.shields.io/gitlab/issues/all/'+j.gitlab+'?color=yellow'}}" alt="issues">
 {% if j.description is defined %}
@@ -48,6 +56,9 @@ Tags: {% for tag in j.tags.split() %} {bdg-light}`{{ tag }}` {% endfor %}
 
 ## {fab}`git-alt;1em` [{{j.name}}]({{j.url}})
 
+{% if j.license is defined %}
+<img src='https://img.shields.io/badge/license-{{ j.license | replace("-", "--") | replace("_", "__") }}-blue' alt="license">
+{% endif %}
 {% if j.description is defined %}
 {{j.description}}
 {% endif %}

--- a/source/packages/programming.md
+++ b/source/packages/programming.md
@@ -16,7 +16,11 @@ A rich ecosystem of high-performance code
 
 ## {fab}`github;1em` [{{j.name}}]({{"https://github.com/"+j.github}})
 <img src="{{'https://img.shields.io/github/v/release/'+j.github+'?color=green'}}" alt="Release">
+{% if j.license is defined %}
+<img src='https://img.shields.io/badge/license-{{ j.license | replace("-", "--") | replace("_", "__") }}-blue' alt="license">
+{% else %}
 <img src="{{'https://img.shields.io/github/license/'+j.github}}" alt="license">
+{% endif %}
 <img src="{{'https://img.shields.io/github/stars/'+j.github}}" alt="stars">
 <img src="{{'https://img.shields.io/github/forks/'+j.github}}" alt="forks">
 <img src="{{'https://img.shields.io/github/last-commit/'+j.github+'?color=blue'}}" alt="last-commit">
@@ -34,7 +38,11 @@ Tags: {% for tag in j.tags.split() %} {bdg-light}`{{ tag }}` {% endfor %}
 ## {fab}`gitlab;1em` [{{j.name}}]({{"https://gitlab.com/"+j.gitlab}})
 
 <img src="{{'https://img.shields.io/gitlab/v/release/'+j.gitlab+'?date_order_by=created_at&sort=date&color=green'}}" alt="Release">
+{% if j.license is defined %}
+<img src='https://img.shields.io/badge/license-{{ j.license | replace("-", "--") | replace("_", "__") }}-blue' alt="license">
+{% else %}
 <img src="{{'https://img.shields.io/gitlab/license/'+j.gitlab}}" alt="license">
+{% endif %}
 <img src="{{'https://img.shields.io/gitlab/forks/'+j.gitlab}}" alt="forks">
 <img src="{{'https://img.shields.io/gitlab/issues/all/'+j.gitlab+'?color=yellow'}}" alt="issues">
 {% if j.description is defined %}
@@ -48,6 +56,9 @@ Tags: {% for tag in j.tags.split() %} {bdg-light}`{{ tag }}` {% endfor %}
 
 ## {fab}`git-alt;1em` [{{j.name}}]({{j.url}})
 
+{% if j.license is defined %}
+<img src='https://img.shields.io/badge/license-{{ j.license | replace("-", "--") | replace("_", "__") }}-blue' alt="license">
+{% endif %}
 {% if j.description is defined %}
 {{j.description}}
 {% endif %}

--- a/source/packages/scientific.md
+++ b/source/packages/scientific.md
@@ -16,7 +16,11 @@ A rich ecosystem of high-performance code
 
 ## {fab}`github;1em` [{{j.name}}]({{"https://github.com/"+j.github}})
 <img src="{{'https://img.shields.io/github/v/release/'+j.github+'?color=green'}}" alt="Release">
+{% if j.license is defined %}
+<img src='https://img.shields.io/badge/license-{{ j.license | replace("-", "--") | replace("_", "__") }}-blue' alt="license">
+{% else %}
 <img src="{{'https://img.shields.io/github/license/'+j.github}}" alt="license">
+{% endif %}
 <img src="{{'https://img.shields.io/github/stars/'+j.github}}" alt="stars">
 <img src="{{'https://img.shields.io/github/forks/'+j.github}}" alt="forks">
 <img src="{{'https://img.shields.io/github/last-commit/'+j.github+'?color=blue'}}" alt="last-commit">
@@ -34,7 +38,11 @@ Tags: {% for tag in j.tags.split() %} {bdg-light}`{{ tag }}` {% endfor %}
 ## {fab}`gitlab;1em` [{{j.name}}]({{"https://gitlab.com/"+j.gitlab}})
 
 <img src="{{'https://img.shields.io/gitlab/v/release/'+j.gitlab+'?date_order_by=created_at&sort=date&color=green'}}" alt="Release">
+{% if j.license is defined %}
+<img src='https://img.shields.io/badge/license-{{ j.license | replace("-", "--") | replace("_", "__") }}-blue' alt="license">
+{% else %}
 <img src="{{'https://img.shields.io/gitlab/license/'+j.gitlab}}" alt="license">
+{% endif %}
 <img src="{{'https://img.shields.io/gitlab/forks/'+j.gitlab}}" alt="forks">
 <img src="{{'https://img.shields.io/gitlab/issues/all/'+j.gitlab+'?color=yellow'}}" alt="issues">
 {% if j.description is defined %}
@@ -48,6 +56,9 @@ Tags: {% for tag in j.tags.split() %} {bdg-light}`{{ tag }}` {% endfor %}
 
 ## {fab}`git-alt;1em` [{{j.name}}]({{j.url}})
 
+{% if j.license is defined %}
+<img src='https://img.shields.io/badge/license-{{ j.license | replace("-", "--") | replace("_", "__") }}-blue' alt="license">
+{% endif %}
 {% if j.description is defined %}
 {{j.description}}
 {% endif %}

--- a/source/packages/strings.md
+++ b/source/packages/strings.md
@@ -16,7 +16,11 @@ A rich ecosystem of high-performance code
 
 ## {fab}`github;1em` [{{j.name}}]({{"https://github.com/"+j.github}})
 <img src="{{'https://img.shields.io/github/v/release/'+j.github+'?color=green'}}" alt="Release">
+{% if j.license is defined %}
+<img src='https://img.shields.io/badge/license-{{ j.license | replace("-", "--") | replace("_", "__") }}-blue' alt="license">
+{% else %}
 <img src="{{'https://img.shields.io/github/license/'+j.github}}" alt="license">
+{% endif %}
 <img src="{{'https://img.shields.io/github/stars/'+j.github}}" alt="stars">
 <img src="{{'https://img.shields.io/github/forks/'+j.github}}" alt="forks">
 <img src="{{'https://img.shields.io/github/last-commit/'+j.github+'?color=blue'}}" alt="last-commit">
@@ -34,7 +38,11 @@ Tags: {% for tag in j.tags.split() %} {bdg-light}`{{ tag }}` {% endfor %}
 ## {fab}`gitlab;1em` [{{j.name}}]({{"https://gitlab.com/"+j.gitlab}})
 
 <img src="{{'https://img.shields.io/gitlab/v/release/'+j.gitlab+'?date_order_by=created_at&sort=date&color=green'}}" alt="Release">
+{% if j.license is defined %}
+<img src='https://img.shields.io/badge/license-{{ j.license | replace("-", "--") | replace("_", "__") }}-blue' alt="license">
+{% else %}
 <img src="{{'https://img.shields.io/gitlab/license/'+j.gitlab}}" alt="license">
+{% endif %}
 <img src="{{'https://img.shields.io/gitlab/forks/'+j.gitlab}}" alt="forks">
 <img src="{{'https://img.shields.io/gitlab/issues/all/'+j.gitlab+'?color=yellow'}}" alt="issues">
 {% if j.description is defined %}
@@ -48,6 +56,9 @@ Tags: {% for tag in j.tags.split() %} {bdg-light}`{{ tag }}` {% endfor %}
 
 ## {fab}`git-alt;1em` [{{j.name}}]({{j.url}})
 
+{% if j.license is defined %}
+<img src='https://img.shields.io/badge/license-{{ j.license | replace("-", "--") | replace("_", "__") }}-blue' alt="license">
+{% endif %}
 {% if j.description is defined %}
 {{j.description}}
 {% endif %}


### PR DESCRIPTION
Fixes https://github.com/fortran-lang/webpage/issues/553

Part of the [Fortran Index](https://github.com/fortran-index/fortran-index) project (https://github.com/fortran-index/fortran-index/issues/23)

---

If a license field is provided in `package_index.yml`, the license badge is generated using the [shields.io static badge generator](https://shields.io/badges/static-badge). This fixes numerous packages which display licenses as "not identifiable by github" and packages hosted on BitBucket (or elsewhere) that currently don't display any license info.