### PR TITLE
Add dtFFT package to index

### DIFF
--- a/data/package_index.yml
+++ b/data/package_index.yml
@@ -1123,6 +1123,13 @@
   tags: machine-learning convolutional-neural-networks
   license: MIT
 
+- name: dtFFT
+  github: ShatrovOA/dtFFT
+  description: a high-performance library designed for parallel data transpositions and optional Fast Fourier Transforms (FFTs) in multidimensional computing environments.
+  categories: numerical
+  tags: mpi cuda fft parallel distributed-memory
+  license: GPL-3.0
+
 # --- Scientific codes ---
 
 - name: astro-fortran


### PR DESCRIPTION
This PR adds https://github.com/ShatrovOA/dtFFT/ to the package index.

### **Required**

- **Relevance** - `dtFFT` is a high-performance library designed for parallel data transpositions and optional Fast Fourier Transforms (FFTs) in multidimensional computing environments.
- **Maturity** - The code is stable, with regular updates, and the repository is actively developed.
- **Availability** - The source code is freely available on GitHub.
- **Open source** - The package is licensed under the GPL-3.0 License, ensuring it remains free and open-source.
- **Uniqueness** - This is an original repository, not a fork.
- **README** - The README file exists and clearly states the purpose of the project. Installation steps, building the code, and running the tests are detailed in the documentation.

### **Recommended**
- **Documentation** - Consists of two parts: [user-friendly](https://dtfft.readthedocs.io/latest/index.html) and [auto-generated](https://shatrovoa.github.io/dtFFT/index.html) via FORD.
- **Contributing** - Ways of contributing are listed in the README file.
- **Tests** - Available for all provided interfaces: Fortran, C, and C++.