### PR TITLE
Delete duplicated entries

### DIFF
--- a/data/intrinsics.yml
+++ b/data/intrinsics.yml
@@ -12,11 +12,6 @@ numeric:
   - "MOD"
   - "MODULO"
   - "SIGN"
-  - "CSHIFT"
-  - "DOT_PRODUCT"
-  - "EOSHIFT"
-  - "MATMUL"
-  - "PARITY"
   - "NULL"
 
 bit:
@@ -138,7 +133,6 @@ math:
   - "ERFC_SCALED"
   - "GAMMA"
   - "LOG_GAMMA"
-  - "LOG_GAMMA"
   - "NORM2"
 
 cfi:
@@ -184,7 +178,6 @@ transform:
   - "EOSHIFT"
   - "MATMUL"
   - "PARITY"
-  - "NULL"
   - "REDUCE"
 
 system:

--- a/source/learn/intrinsics/_pages/CSHIFT.md
+++ b/source/learn/intrinsics/_pages/CSHIFT.md
@@ -67,8 +67,6 @@ Returns an array of same type and rank as the **array** argument.
 The rows of an array of rank two may all be shifted by the same amount
 or by different amounts.
 
-## cshift
-
 ### **Examples**
 
 Sample program:


### PR DESCRIPTION
In the intrinsics pages, there were some duplicated entries. See
<img width="1499" height="1071" alt="image" src="https://github.com/user-attachments/assets/1fdee0a9-5220-4b2e-8f3a-3384008efe37" />
<img width="1402" height="578" alt="image" src="https://github.com/user-attachments/assets/2bd1c65c-b29c-4f39-a1f0-f8aa369b3539" />

More over, in some pages of intrinsics, the table of contents does not appear (I do not know why). 
This is the case for
- intrinsics/array,
- intrinsics/character,
- intrinsics/system,
<img width="2065" height="1299" alt="image" src="https://github.com/user-attachments/assets/5b667f9e-24e5-4d3a-8aa3-012af163da29" />
