### PR TITLE
Fix broken links by removing /en from fortran-lang.org URLs

### DIFF
--- a/locale/de/LC_MESSAGES/index.po
+++ b/locale/de/LC_MESSAGES/index.po
@@ -262,7 +262,7 @@ msgid ""
 "index](/packages)"
 msgstr ""
 "Siehe {ref}`packages` für das Hinzufügen eines Eintrags zum [Paket "
-"Index](https://fortran-lang.org/en/packages)"
+"Index](https://fortran-lang.org/packages)"
 
 #: ../../source/community/contributing.md:7
 msgid ""

--- a/locale/es/LC_MESSAGES/index.po
+++ b/locale/es/LC_MESSAGES/index.po
@@ -263,7 +263,7 @@ msgid ""
 "index](/packages)"
 msgstr ""
 "Vea {ref}`paquetes` para saber cómo añadir una entrada al [Índice de "
-"paquetes](https://fortran-lang.org/en/packages)"
+"paquetes](https://fortran-lang.org/packages)"
 
 #: ../../source/community/contributing.md:7
 msgid ""

--- a/locale/pt/LC_MESSAGES/index.po
+++ b/locale/pt/LC_MESSAGES/index.po
@@ -41060,7 +41060,7 @@ msgstr ""
 #~ msgstr ""
 #~ "Veja {ref}``packages`` para saber como "
 #~ "adicionar um pacote na [Lista de "
-#~ "Pacotes](https://fortran-lang.org/en/packages)"
+#~ "Pacotes](https://fortran-lang.org/packages)"
 
 #~ msgid ""
 #~ "See {ref}``minibooks`` for how to write "

--- a/locale/zh_CN/LC_MESSAGES/index.po
+++ b/locale/zh_CN/LC_MESSAGES/index.po
@@ -39222,7 +39222,7 @@ msgstr ""
 #~ "an entry to the [Package index](https"
 #~ "://fortran-lang.org/en/packages)"
 #~ msgstr ""
-#~ "有关如何将条目添加到 [包索引](https://fortran-lang.org/en/packages) "
+#~ "有关如何将条目添加到 [包索引](https://fortran-lang.org/packages) "
 #~ "的信息，请参见 {ref}``packages``"
 
 #~ msgid ""

--- a/source/conf.py
+++ b/source/conf.py
@@ -170,7 +170,7 @@ html_theme_options = {
         },
         {
             "name": "RSS",
-            "url": "https://fortran-lang.org/en/news/atom.xml",
+            "url": "https://fortran-lang.org/news/atom.xml",
             "icon": "fas fa-rss",
         },
     ],
@@ -205,8 +205,8 @@ fontawesome_link_cdn = True
 
 blog_path = "news"
 blog_post_pattern = "news/**"
-blog_baseurl = "https://fortran-lang.org/en/"
-html_baseurl = "https://fortran-lang.org/en/"
+blog_baseurl = "https://fortran-lang.org"
+html_baseurl = "https://fortran-lang.org"
 sitemap_url_scheme = "{link}"
 post_redirect_refresh = 1
 post_auto_image = 1

--- a/source/roadmap.md
+++ b/source/roadmap.md
@@ -188,7 +188,7 @@ using Sphinx and MyST Markdown. The documentation should include:
 
 ### Extension Localizations
 
-The aim of the project is to localize the Modern Fortran for Visual Studio Code extension into other languages. There is already extensive documentation on how to localize Visual Studio Code extensions, and we already have tools in place to help with the process, see for example [fortran-lang.org](https://fortran-lang.org/en/).
+The aim of the project is to localize the Modern Fortran for Visual Studio Code extension into other languages. There is already extensive documentation on how to localize Visual Studio Code extensions, and we already have tools in place to help with the process, see for example [fortran-lang.org](https://fortran-lang.org).
 
 **Related issues:**
 


### PR DESCRIPTION
this was for issue #556 