### PR TITLE
Add diffstruc library to package index

### DIFF
--- a/data/package_index.yml
+++ b/data/package_index.yml
@@ -1200,6 +1200,13 @@
   tags: mpi cuda fft parallel distributed-memory
   license: GPL-3.0
 
+- name: diffstruc
+  github: nedtaylor/diffstruc
+  description: A library providing a derived type that enables forward and reverse mode automatic differentiation.
+  categories: numerical
+  tags: automatic-differentiation adjoint algorithmic derivative AD autodiff jacobian hessian
+  license: MIT
+
 # --- Scientific codes ---
 
 - name: astro-fortran


### PR DESCRIPTION
Add [diffstruc](https://github.com/nedtaylor/diffstruc) to the Numerical category.

I believe it conforms with all of the [package criteria](https://fortran-lang.org/community/packages/).

As a note, I wasn't certain which category fitted best. I was debating between Numerical, Data types and Containers, or Libraries. Feel free to recommend if the category I have entered it into (Numerical) should be changed.