### PR TITLE
Fix sidebar links in intrinsics pages

### DIFF
--- a/source/learn/intrinsics/_pages/GET_COMMAND.md
+++ b/source/learn/intrinsics/_pages/GET_COMMAND.md
@@ -107,5 +107,3 @@ Fortran 2003
 [**command_argument_count**(3)](#command_argument_count)
 
 _fortran-lang intrinsic descriptions (license: MIT) \@urbanjost_
-
-#

--- a/source/learn/intrinsics/_pages/GET_COMMAND_ARGUMENT.md
+++ b/source/learn/intrinsics/_pages/GET_COMMAND_ARGUMENT.md
@@ -147,5 +147,3 @@ Fortran 2003
 [**command_argument_count**(3)](#command_argument_count)
 
 _fortran-lang intrinsic descriptions (license: MIT) \@urbanjost_
-
-#

--- a/source/learn/intrinsics/_pages/GET_ENVIRONMENT_VARIABLE.md
+++ b/source/learn/intrinsics/_pages/GET_ENVIRONMENT_VARIABLE.md
@@ -148,5 +148,3 @@ Fortran 2003
 [**get_command**(3)](#get_command)
 
 _fortran-lang intrinsic descriptions (license: MIT) \@urbanjost_
-
-#

--- a/source/learn/intrinsics/_pages/RANK.md
+++ b/source/learn/intrinsics/_pages/RANK.md
@@ -165,5 +165,3 @@ Results:
 - [**btest**(3)](#btest) - Tests a bit of an _integer_ value.
 
 _fortran-lang intrinsic descriptions (license: MIT) \@urbanjost_
-
-#

--- a/source/learn/intrinsics/_pages/REPEAT.md
+++ b/source/learn/intrinsics/_pages/REPEAT.md
@@ -87,5 +87,3 @@ Functions that perform operations on character strings:
   [**trim**(3)](#trim)
 
 _fortran-lang intrinsic descriptions (license: MIT) \@urbanjost_
-
-#


### PR DESCRIPTION
These extra hashes are causing pages to render incorrectly; notably the "On this page" sidebar is not populated on the following pages:

- https://fortran-lang.org/learn/intrinsics/array/
- https://fortran-lang.org/learn/intrinsics/character/
- https://fortran-lang.org/learn/intrinsics/system/