### PR TITLE
Reorder topbar

### DIFF
--- a/source/index.md
+++ b/source/index.md
@@ -149,10 +149,10 @@ Or just write Fortran software for your research, business, or schoolwork. You c
 
 Play <https://dev.lfortran.org/>
 learn
-roadmap
 compilers
-community
 packages
+community
+roadmap
 news
 history
 


### PR DESCRIPTION
Reorders the top-bar to make 'Packages' more prominent and hide the 'Roadmap' page. I personally find the 'Packages' page to be a really useful resource, while the 'Roadmap' page appears to be very out-of-date.

Currently the topbar looks like this:

<img width="1140" height="96" alt="old_topbar" src="https://github.com/user-attachments/assets/efe8a7a5-c188-4dfe-a70a-a87311b8b5f8" />

With 'Packages' and 'News' hidden behind the 'More' dropdown. This PR reorders it to:

<img width="1146" height="102" alt="new_topbar" src="https://github.com/user-attachments/assets/85f5ea79-00ed-4a4c-ae2c-2a22e74a1519" />

With 'Roadmap' and 'News' hidden behind the dropdown.