### PR TITLE
docs(quickstart): fix Hello World output spacing

### DIFF
--- a/source/learn/quickstart/hello_world.md
+++ b/source/learn/quickstart/hello_world.md
@@ -59,7 +59,7 @@ To run your compiled program:
 
 ```console
 $> ./hello
-Hello, World!
+ Hello, World!
 ```
 
 Congratulations, you've written, compiled and run your first Fortran program!


### PR DESCRIPTION
This PR updates the Hello World example shown in the Quickstart guide.

The documentation previously showed the output as:

$> ./hello
Hello, World!

However, when compiled and run using gfortran, the actual output includes a
leading space:

$> ./hello
 Hello, World!

This mismatch can be confusing for beginners following the tutorial.
The example has been updated to accurately reflect the real program output.
Fixes #616
