### PR TITLE
quickstart: C binding module name typo

### DIFF
--- a/source/learn/quickstart/derived_types.md
+++ b/source/learn/quickstart/derived_types.md
@@ -100,7 +100,7 @@ Example with `bind(c)`:
 
 ```{play-code-block} fortran
 module f_to_c
-  use iso_c_bindings, only: c_int
+  use iso_c_binding, only: c_int
   implicit none
 
   type, bind(c) :: f_type


### PR DESCRIPTION
As simple as that.