### PR TITLE
Link to SIG-RPC Fortran optimisations page

### DIFF
--- a/data/learning.yml
+++ b/data/learning.yml
@@ -337,6 +337,10 @@ reference-links:
     url: https://stevelionel.com/drfortran
     description: A collection of posts on interesting or little-understood aspects of the Fortran language
 
+  - name: "Fortran optimisation patterns (Reasonable Performance Computing Special Interest Group)"
+    url: https://sig-rpc.github.io/optimisations/fortran/
+    description: A collection of recommendations on common Fortran optimisation patterns.
+
 reference-course-providers:
   - name: "ARCHER2 service training UK"
     url: https://www.archer2.ac.uk/training/#upcoming-training


### PR DESCRIPTION
Closes https://github.com/fortran-index/fortran-index/issues/27.

This afternoon we're holding a Fortran index hackathon in collaboration with the [Special Interest Group for Reasonable Performance Computing (SIG-RPC)](https://sig-rpc.github.io/), in which attendees will add Fortran optimisation patterns to their [optimisations database](https://sig-rpc.github.io/optimisations/). The intention is for these to be useful for helping researchers write efficient Fortran, so this feels relevant to the learn section of fortran-lang.