### PR TITLE
Fix search box overlap on packages page

### DIFF
--- a/source/packages.md
+++ b/source/packages.md
@@ -15,9 +15,17 @@ A rich ecosystem of high-performance code
 :::{div} sd-fs-3 sd-font-weight-bold sd-text-primary
 Find a Package
 :::
+<form class="bd-search d-flex align-items-center" align="center" action="../search/index.html" method="get" style="margin-bottom: 30px;"> 
+  <input type="search" class="form-control" name="q" id="search-input" list="package-options" placeholder="Search for a package" aria-label="Search" autocomplete="off" style='margin: auto;text-align: center;width:40em;'> 
+</form>
 
-<form class="bd-search d-flex align-items-center" align="center" action="../search/index.html" method="get">  <input type="search" class="form-control" name="q" id="search-input" placeholder="Search for a package" aria-label="Search" autocomplete="off" style='margin: auto;text-align: center;width:40em;'> </form>
-
+:::{jinja} fortran_index
+<datalist id="package-options">
+  {% for package in fortran_index %}
+      <option value="{{ package.name }}"></option>
+  {% endfor %}
+</datalist>
+:::
 :::::{grid} 2
 
 ::::{grid-item-card}


### PR DESCRIPTION

This pull request addresses a UI layout bug on the Fortran Packages page where the bottom border of the "Search for a package" input box was visually overlapping with the "Package index" and "Featured topics" headings directly below it. To solve this issue, I modified the HTML structure in the source/packages.md file by adding a margin-bottom: 30px; inline CSS style to the  container that wraps the search input. This change introduces adequate spacing between the search bar and the subsequent grid elements, completely resolving the text clash and ensuring a cleaner, more readable user interface.
<img width="1920" height="942" alt="Screenshot (117)" src="https://github.com/user-attachments/assets/9f01f2a9-47fb-4724-8cce-294cc41735be" />
solves #629