### PR TITLE
WIP: Fetching package data from GitHub during build process

### DIFF
--- a/fortran_package.py
+++ b/fortran_package.py
@@ -2,9 +2,17 @@ import yaml
 from pathlib import Path
 from collections import Counter
 import json
+import os
 import requests
 
 root = Path(__file__).parent
+
+packages = root / "data" / "packages"
+if not packages.exists():
+    packages.mkdir(parents=True)
+
+token: str | None = os.getenv("GITHUB_TOKEN")
+"""GitHub token for fetching package data, if available."""
 
 with open(root / "data" / "package_index.yml", "r") as f:
     fortran_index = yaml.safe_load(f)
@@ -90,3 +98,35 @@ contributor_repo = {"repo": "fortran-lang", "contributor": contributors}
 
 with open(root / "_data" / "contributor.json", "w") as f:
     json.dump(contributor_repo, f)
+
+
+class MissingTokenError(Exception):
+    """Exception raised when the GITHUB_TOKEN environment variable is not set."""
+    pass
+
+
+def fetch_package_data(org: str, repo: str) -> dict[str, str]:
+    """
+    Fetch the package data for all packages in the documentation.
+    """
+
+    if token is None:
+        raise MissingTokenError("Warning: No GITHUB_TOKEN environment variable set, skipping package data fetch.")
+
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"Bearer {token}",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+    print(f"Fetching package data for {org}/{repo}...")
+
+    return requests.get(f"https://api.github.com/repos/{org}/{repo}", headers=headers).json()
+
+for package in fortran_index:
+    if "github" not in package:
+        continue
+    org, repo = package["github"].split("/")
+    data = fetch_package_data(org, repo)
+    with open(packages / f"{org}_{repo}.json", "w") as f:
+        json.dump(data, f)

--- a/source/conf.py
+++ b/source/conf.py
@@ -34,10 +34,9 @@ data_files = {
 
 sys.path.insert(0, str(root / "extensions"))
 
-if not all(data.exists() for data in data_files.values()):
-    sys.path.insert(0, str(root.absolute()))
-    # pylint: disable=import-error, unused-import
-    import fortran_package
+sys.path.insert(0, str(root.absolute()))
+# pylint: disable=import-error, unused-import
+import fortran_package
 
 with open(data_files["fortran-learn"], "r", encoding="utf-8") as f:
     conf = json.load(f)


### PR DESCRIPTION
Created for a [Fortran index hackathon](https://github.com/fortran-index/fortran-index).

The package index uses badges from [shields.io](https://github.com/fortran-index/fortran-index) to display things such as stars, forks, time since last commit, etc. It would be useful if it were possible to filter on this info, e.g. only show repos that have had a commit in the last 3 years.

To do this, we could grab the required info directly from GitHub's public API as part of the build process. This PR demonstrates a simple way to achieve this.

I think it would be preferable to add the new code to a different file and leave `fortran_package.py` alone. It also takes a long time to read all of this data and most of it isn't needed, so it would be preferable to use GitHub's [GraphQL API](https://docs.github.com/en/graphql). The queries would look like:

```graphql
query Repos {
  r1: repository(owner: "dftbplus", name: "scalapackfx") {
    nameWithOwner
    stargazerCount
    ...
  }
  r2: repository(owner: "scientific-computing", name: "FKB") {
    nameWithOwner
    stargazerCount
    ...
  }
  r3: repository(owner: "swig-fortran", name: "flibcpp") {
    nameWithOwner
    stargazerCount
    ...
  }
  ...
}

```

(Credit to https://github.com/nikolaushuber for the GraphQL info)

The next step would be to update the content in a lot of the templated markdown files to include some sort of searchable table, but I haven't found a good solution for that yet.