### PR TITLE
Bump Python version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Setup Fortran compiler
         uses: fortran-lang/setup-fortran@v1.9.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Setup Fortran compiler
         uses: fortran-lang/setup-fortran@v1.9.0

--- a/.github/workflows/preview_build.yml
+++ b/.github/workflows/preview_build.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install sphinx
         run: pip3 install --user -r requirements.txt

--- a/.github/workflows/preview_build.yml
+++ b/.github/workflows/preview_build.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Install sphinx
         run: pip3 install --user -r requirements.txt


### PR DESCRIPTION
Dependabot set a Sphinx version that isn't available at Python 3.11, which is used in the CI:
https://github.com/fortran-lang/webpage/actions/runs/23347547590/job/67916954602

This is a hotfix following merging #648.