### PR TITLE
Update outdated community links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 ## Contributing
 
-- [contributing](https://fortran-lang.github.io/webpage/en/community/contributing):
+- [contributing](https://fortran-lang.org/community/contributing/):
   getting started and general guidance on contributing to <https://fortran-lang.org>
 
-- [minibooks](https://fortran-lang.github.io/webpage/en/community/minibooks):
+- [minibooks](https://fortran-lang.org/community/minibooks/):
   how to write and structure a mini-book tutorial for the [Learn](https://fortran-lang.org/learn) section
 
-- [packages](https://fortran-lang.github.io/webpage/en/community/packages):
+- [packages](https://fortran-lang.org/community/packages/):
   adding an entry to the [Package index](https://fortran-lang.org/packages)
 
 ## Setup


### PR DESCRIPTION
## Summary
- replace outdated community links in the README with the current fortran-lang.org URLs
- update the contributing, minibooks, and packages links in the same section for consistency

## Testing
- verified the current README still points to legacy ortran-lang.github.io/webpage/... URLs
- verified the current live community pages are hosted under https://fortran-lang.org/community/.../

Closes #665