### PR TITLE
docs: make governance page easier to find

### DIFF
--- a/source/community.md
+++ b/source/community.md
@@ -155,11 +155,17 @@ on the project workflow and recommended practices.
 [Contributor guide for fpm](https://github.com/fortran-lang/fpm/blob/HEAD/CONTRIBUTING.md)<br>
 [Contributor guide for fortran-lang.org](community/contributing)
 
+::::
+
+::::{grid-item-card}
+:shadow: none
+
 :::{div} sd-text-left sd-fs-4
 Fortran-lang governance
 :::
 
-The [governance](community/governance) model used by the Fortran-lang community
+Learn how the Fortran-lang community is organized, how responsibilities are shared,
+and where to find the current [governance model](community/governance).
 ::::
 ::::{grid-item-card}
 :shadow: none
@@ -232,6 +238,7 @@ Fortran-lang Contributors
 :hidden:
 community/history
 community/contributing
+community/governance
 community/minibooks
 community/packages
 :::


### PR DESCRIPTION
## Summary
- split governance into its own card on the community page
- add clearer copy that explains what the governance page contains
- include the governance page in the hidden toctree for better discoverability

Closes #211