### PR TITLE
Fix: Futility has moved its repository

### DIFF
--- a/data/package_index.yml
+++ b/data/package_index.yml
@@ -99,7 +99,7 @@
   version: none
 
 - name: Futility
-  github: CASL/Futility
+  url: https://code.ornl.gov/futility/Futility
   description: Fortran utilities including unit test harness, arbitrary length strings, parameter list objects, timers, geometry definitions, file wrappers, linear algebra tools, and parallel computing support
   categories: libraries interfaces programming strings io numerical scientific
   version: none


### PR DESCRIPTION
As the README of [Futility on GitHub](https://github.com/CASL/Futility) says, the project has moved to a [different host server](https://code.ornl.gov/futility/Futility).

Although, it is only a small change, I tried to test it locally. However, the [instruction for this in the README](https://code.ornl.gov/futility/Futility) seems to be incomplete. I did the following commands on my Manjaro Linux machine:

```zsh
python -m venv .venv
source  .venv/bin/activate
pip3 install -r requirements.txt
sphinx-build --version
python3 build.py
```
Then it fails with
```
FileNotFoundError: [Errno 2] File or directory not found: 'gfortran'
```
