### PR TITLE
fix(playground): direct gfortran .mod output into build/ (#675)

### DIFF
--- a/extensions/fortran_playground.py
+++ b/extensions/fortran_playground.py
@@ -27,7 +27,8 @@ class PlayCodeBlock(CodeBlock):
         # -J build/ directs module (.mod) output into the build directory
         # alongside the .out and cache files. Without it, gfortran writes
         # .mod files to the working directory (the project root), which
-        # leaves them dangling after a successful build. See #675.
+        # leaves them dangling after a successful build. See
+        # https://github.com/fortran-lang/webpage/issues/675
         compile_command = [
             "gfortran",
             "-J",

--- a/extensions/fortran_playground.py
+++ b/extensions/fortran_playground.py
@@ -24,7 +24,18 @@ class PlayCodeBlock(CodeBlock):
         with open(filename, "w") as f:
             f.write(fortran_code)
 
-        compile_command = ["gfortran", filename, "-o", f"./build/{code_hash}.out"]
+        # -J build/ directs module (.mod) output into the build directory
+        # alongside the .out and cache files. Without it, gfortran writes
+        # .mod files to the working directory (the project root), which
+        # leaves them dangling after a successful build. See #675.
+        compile_command = [
+            "gfortran",
+            "-J",
+            "build",
+            filename,
+            "-o",
+            f"./build/{code_hash}.out",
+        ]
         compile_result = subprocess.run(
             compile_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE
         )


### PR DESCRIPTION
Closes #675.

## What changed

Added \`-J build\` to the gfortran invocation in \`extensions/fortran_playground.py:PlayCodeBlock.compile_and_execute_fortran\`.

\`\`\`diff
- compile_command = ["gfortran", filename, "-o", f"./build/{code_hash}.out"]
+ compile_command = [
+     "gfortran",
+     "-J", "build",
+     filename,
+     "-o", f"./build/{code_hash}.out",
+ ]
\`\`\`

## Why this matches the issue

The issue says:

> The webpage build process compiles some Fortran code and leaves \`.mod\` module files lying around. It would be good to remove these at the end of a successful build.

\`gfortran\`'s default is to write \`.mod\` files into the current working directory of the gfortran process — which during a Sphinx run is the project root, *not* \`build/\`. The \`.out\` binaries and the cached \`fortran_output_<hash>.txt\` already go into \`build/\` (which is \`.gitignore\`-d). \`-J <dir>\` is the standard gfortran flag that tells the compiler where to put module files; pointing it at \`build\` keeps the \`.mod\` files siblings to everything else the directive produces.

After the change, the \`.gitignore\` entry for \`/build/\` covers all four artifact types (.f90 source, .out binaries, output cache, .mod modules). \`make\` cleanup paths and fresh checkouts stay tidy with no other changes.

I considered the alternative — globbing and removing \`.mod\` files after the compile finishes — but that's strictly more code, has to handle compile-failure cleanup separately, and doesn't help if a parallel build creates a \`.mod\` mid-run. \`-J\` solves both at once.

## Verification

- \`python -c "import ast; ast.parse(...)"\` parses the updated module cleanly.
- The compile command list is otherwise byte-identical to before; behavior other than module-file destination is unchanged.
- I don't have \`gfortran\` available locally for a runtime smoke test, so the build CI on this PR is the canonical check.