### PR TITLE
docs: mention gfortran dependency in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ To install the dependencies of this project, use commamd:
 pip3 install --user -r requirements.txt
 ```
 
+Local builds also require the GNU Fortran compiler `gfortran`.
+For example on Ubuntu you can install it with:
+
+```
+sudo apt install gfortran
+```
+
 To install sphinx (if system is not able to recognize sphinx-build after installing requirements) :
 
 First check :

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 This assumes that you already have a recent version of python
 For example on Ubuntu 20.04, do:
 
-To install the dependencies of this project, use commamd:
+To install the dependencies of this project, use the command:
 
 ```
 pip3 install --user -r requirements.txt


### PR DESCRIPTION
## Summary

- mention `gfortran` as a prerequisite for local builds in the root README
- add a minimal Ubuntu install example

Closes #672
