### PR TITLE
Add blog post on BTTFF3

### DIFF
--- a/source/news/2026/05-05-Back-to-the-Fortran-Future-3.md
+++ b/source/news/2026/05-05-Back-to-the-Fortran-Future-3.md
@@ -1,0 +1,38 @@
+---
+category: blogpost
+date: 2026-05-05
+author: Liam Pattinson, Austen Rainer, Andrew Brown, Joe Wallwork, Connor Aird
+...
+
+# Back to the Fortran Future 3
+
+The Software Sustainability Institute’s (SSI) Collaborations Workshop 2026 attracted around a hundred researchers, research software engineers (RSEs), and other research technical professionals (RTPs) to sunny – yes, sunny – Belfast to discuss the future of the digital research landscape: alternative academic career paths, the impact of AI, green computing, and more. But before that, a small number of eccentric individuals gathered at a secretive location to discuss something much older: Fortran, the language to have survived more false obituaries than any other. Back to the Fortran Future 3 brought together some of the more dedicated members of the UK Fortran community to coordinate, strategise, and discuss an exciting new opportunity.
+
+This workshop series started as a satellite event of RSECon 2024 in Newcastle, where the focus was on bringing together the community and identifying our shared challenges. Fortran developers have historically been an isolated bunch, and the 2024 workshop served as a lightning rod, drawing in RSEs, educators, and community managers from across academia, national labs, and industry, from the UK and beyond. It spawned a number of new initiatives, including the [Fortran Index](https://fortran-index.github.io/) Hackathon series, which aims to improve the Fortran-Lang website and make it easier to find useful Fortran packages, and the [Fortitude linter](https://fortitude.readthedocs.io/en/stable/), which performs static analysis of Fortran code to help RSEs and computational scientists write safer, cleaner, and more modern software.
+
+The second workshop kicked off the week at RSECon25 at Warwick and aimed to gain feedback and momentum for the various ongoing projects. It was just as popular as the first workshop, with around 50 attendees from a diverse set of institutions. As well as talks on Fortran Index and the Fortitude Linter, Brad Richardson gave a talk on the [fpm fortran package manager](https://fpm.fortran-lang.org/), and John Pelan updated the community on the transition of the [Fortran Specialist Group](https://society-rse.org/fortran-specialist-group/) from the British Computer Society to the Society of Research Software Engineers (SocRSE).
+
+That brings us to the third workshop, taking place the day before SSI’s Collaborations Workshop 2026 in Belfast, where it was clear that this work is paying off. Joe Wallwork's Fortran Index project is now supported by a [CAKE Fellowship](https://fortran-lang.org/news/2026/01-23-Fortran-index-blogpost/), and for his efforts he was invited to be a direct contributor to the Fortran-Lang website. Liam Pattinson has earned an SSI Fellowship to support community contributions to the Fortitude linter. Connor Aird has successfully run workshops on proper [testing practices in Fortran](https://carpentries-incubator.github.io/fortran-unit-testing/) at University College London and is planning to run them at other  institutions, while Dimitri Theodorakis has been hard at work developing [Fortran Carpentries lessons](https://carpentries-incubator.github.io/intro-to-modern-fortran/).
+
+The headline of the event, however, was the recently funded FortranFuture EPSRC Network+ (UKRI4343). FortranFuture is both an international community of practice, comprising research software engineers, computational scientists and others, and an interdisciplinary research network seeking to answer the high level question:
+
+*How do we sustain sciences, and engineering disciplines, currently dependent on Fortran so that they continue to advance knowledge – and contribute to society, the economy and the environment – for the next 70 years?*
+
+The network already has ~25 institutional partners in the UK, Europe and the USA and, separately, a community of practice of 75+ practitioners, also UK and international, including research software engineers, computational scientists and other stakeholders.
+
+Part of the network's function will be to provide seed-funding to small projects that will benefit the Fortran community, e.g. funding tool or resource development, or events to bring the community together. 
+
+The workshop also discussed preliminary results of an international survey on the state of the global Fortran community and ecosystem.
+
+After a satisfying lunch, the afternoon saw us classify the archetypical Fortran developers and collaborate to identify their needs. These included:
+
+* Ellie the Early Career inheritor: a PhD student who has inherited a large Fortran codebase from their supervisor
+* Roger the retiring solo guardian: a professor, nearing retirement, who is the sole maintainer of an important Fortran application
+* Rachel the RSE in the middle: an RSE who is working on someone else’s Fortran code as part of her job in a central university RSE group
+* Nesta the national lab HPC scientist: a computational scientist who is responsible for building GPU acceleration into a large, community maintained Fortran application
+* Oscar the open source software volunteer: a hobbyist who has written a tool to support Fortran development in his spare time
+* Isla the industry engineer: a research technical professional responsible for making sure the company’s flagship fortran products work on all their customers’ machines
+
+The discussion raised many questions. Does Ellie have access to the resources she needs, and if not, does her supervisor know where to turn? Are Isla, Rachel and Nesta able to collaborate to share best practices, or are there structural barriers getting in the way? How can we reach isolated developers such as Oscar and Roger to ensure they’re getting much needed support? We hope to answer these as the network continues to grow and move forward.
+
+**Back to the Fortran Future will return!** The next workshop, the fourth in a series that is threatening to match the output of the Fast & Furious film franchise, will take place in Sheffield on Tuesday 8th September as a satellite event to RSECon 2026. Register [here](https://luma.com/33mdqtt4) to book your place.


### PR DESCRIPTION
This blog post will also be published on the SSI website. Once that has happened, we should add a note with a link to it at the bottom of the post.