### PR TITLE
Refactor Python code

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 ### Build fortran-lang.org site (Sphinx Version)
 
-This assumes that you already have a recent version of python
+This assumes that you already have a recent version of python.
 For example on Ubuntu 20.04, do:
 
 To install the dependencies of this project, use the command:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# New fortran-lang.org website
+# fortran-lang.org website
 
 ## Contributing
 
@@ -26,58 +26,53 @@ pip3 install --user -r requirements.txt
 
 Local builds also require the GNU Fortran compiler `gfortran`.
 For example on Ubuntu you can install it with:
-
-```
+```sh
 sudo apt install gfortran
 ```
+To install sphinx (if system is not able to recognize sphinx-build after installing requirements):
 
-To install sphinx (if system is not able to recognize sphinx-build after installing requirements) :
-
-First check :
-```
+First check:
+```sh
 sphinx-build --version
 ```
 
 if not recognized then run:
-```
+```sh
 pip install -U sphinx
 ```
 
 Build the site by invoking
-
-```
+```sh
 python3 build.py
 ```
 
 The website will be built in `build/html` and can be previewed by starting a webserver and opening the page with a browser (_e.g._ firefox, chromium or similar):
-
-```
+```sh
 python3 -m http.server -d build/html
 ```
 
 By default all languages will be built.
 To limit the build to a single language subtree, _i.e._ English, use
-
-```
+```sh
 python3 build.py en
 ```
 
 After adding a new entry to package index, run the github action _fortran_packages_ before building the sphinx build.
 
-### Activating the pre-commit hooks for Black and Pylint:
+### Activating the pre-commit hooks for Ruff:
 
 This assumes that you already have a cloned the main branch of this repository.
 Steps to activate the pre-commit hooks are:
 
 1. Make sure that you have installed all the dependencies of the repository.
 
-```
+```sh
 pip3 install --user -r requirements.txt
 ```
 
 2. Activate the pre-commit hooks:
 
-```
+```sh
 pre-commit install
 ```
 
@@ -85,18 +80,10 @@ Now, the precommit hooks have been successfully been installed into your clone.
 
 #### Steps to debug/resolve issues which prevent the commit due to pre-commit hooks:
 
-1. if pylint causes the issues in commiting to the repo, and it seems mandatory to `skip`
-   the pre-commit hooks use:
-
-```
-SKIP=pylint git commit -m"my commit"`
-```
-
-2. if black causes the issues in commiting to the repo, and it seems mandatory to `skip`
-   the pre-commit hooks use:
-
-```
-SKIP=black git commit -m"my commit"
+If linting causes the issues in commiting to the repo, and it seems mandatory to
+`skip` the pre-commit hooks use:
+```sh
+git commit -m"my commit" --no-verify
 ```
 
 ### Translating via weblate
@@ -115,7 +102,7 @@ which contain the original sentences and a placeholder for translations.
 
 To update translations run
 
-```
+```sh
 python3 intl.py
 ```
 

--- a/build.py
+++ b/build.py
@@ -77,7 +77,7 @@ def build_all(redirects: Dict[str, str], languages: List[str]) -> None:
 if __name__ == "__main__":
     # Error handling for data loading
     try:
-        with open(root / "data" / "redirects.yml", "r", encoding="utf-8") as fd:
+        with (root / "data" / "redirects.yml").open() as fd:
             # All redirects from the original site without language component.
             all_redirects: Dict[str, str] = yaml.safe_load(fd)
 

--- a/build.py
+++ b/build.py
@@ -89,20 +89,6 @@ def build_docs(language: str, isroot: bool) -> None:
     )
 
 
-def build_redirects(redirects: Dict[str, str], language: str) -> None:
-    """
-    Build the redirects for a single language.
-
-    Parameters
-    ----------
-    redirects : Dict[str, str]
-        Page redirects to build.
-    language : str
-        The language to build the redirects for.
-    """
-    pass
-
-
 def build_all(redirects: Dict[str, str], languages: List[str]) -> None:
     """
     Build the documentation for all languages.
@@ -118,14 +104,12 @@ def build_all(redirects: Dict[str, str], languages: List[str]) -> None:
     for language in languages:
         build_docs(language, language == languages[0])
 
-    build_redirects(redirects, languages[0])
-
 
 if __name__ == "__main__":
     build_all(all_redirects, sys.argv[1:] if len(sys.argv) > 1 else all_languages)
 
     python_cmd = Path(sys.executable).name
-    
+
     print()
     print("Preview the fortran-lang.org site using")
     print()

--- a/build.py
+++ b/build.py
@@ -34,21 +34,6 @@ outdir: Path = root / "build" / "html"
 srcdir: Path = root / "source"
 """Directory containing the Sphinx configuration file."""
 
-# Error handling for data loading
-try:
-    with open(root / "data" / "redirects.yml", "r", encoding="utf-8") as fd:
-        # All redirects from the original site without language component.
-        all_redirects: Dict[str, str] = yaml.safe_load(fd)
-
-    with open(root / "data" / "languages.yml", "r", encoding="utf-8") as fd:
-        # List of currently supported languages, taken from `doc/src/_static/languages.yml`.
-        all_languages: List[str] = list(yaml.safe_load(fd).values())
-except FileNotFoundError as e:
-    raise FileNotFoundError(
-        f"Error: Required data file not found: {e.filename}\n"
-        "Ensure you are running build.py from the root of the repository."
-    ) from e
-
 
 def build_docs(language: str, isroot: bool) -> None:
     """
@@ -91,10 +76,26 @@ def build_all(redirects: Dict[str, str], languages: List[str]) -> None:
 
 
 if __name__ == "__main__":
+    # Error handling for data loading
+    try:
+        with open(root / "data" / "redirects.yml", "r", encoding="utf-8") as fd:
+            # All redirects from the original site without language component.
+            all_redirects: Dict[str, str] = yaml.safe_load(fd)
+
+        with open(root / "data" / "languages.yml", "r", encoding="utf-8") as fd:
+            # List of currently supported languages, taken from `doc/src/_static/languages.yml`.
+            all_languages: List[str] = list(yaml.safe_load(fd).values())
+    except FileNotFoundError as e:
+        raise FileNotFoundError(
+            f"Error: Required data file not found: {e.filename}\n"
+            "Ensure you are running build.py from the root of the repository."
+        ) from e
+
+    # Build the website
     build_all(all_redirects, sys.argv[1:] if len(sys.argv) > 1 else all_languages)
 
+    # Tell the user how to set up a server
     python_cmd = Path(sys.executable).name
-
     print()
     print("Preview the fortran-lang.org site using")
     print()

--- a/build.py
+++ b/build.py
@@ -49,21 +49,6 @@ except FileNotFoundError as e:
         "Ensure you are running build.py from the root of the repository."
     ) from e
 
-template = """
-<!DOCTYPE HTML>
- 
-<meta charset="UTF-8">
-<meta http-equiv="refresh" content="1; url={0}">
- 
-<script>
-  window.location.href = "{0}"
-</script>
- 
-<title>Page Redirection</title>
- 
-If you are not redirected automatically, follow the <a href='{0}'>link</a>.
-"""
-
 
 def build_docs(language: str, isroot: bool) -> None:
     """

--- a/build.py
+++ b/build.py
@@ -17,7 +17,6 @@ You can also pass the language as an argument:
 
 The first language will be handled as the default language.
 """
-# pylint: disable=invalid-name,import-error
 
 import sys
 import subprocess

--- a/fortran_package.py
+++ b/fortran_package.py
@@ -68,13 +68,15 @@ def update_json_files() -> None:
                     fortran_tags[j] = [i]
 
     fortran_index_tags_data = Counter(fortran_index_tags)
-    tags = {"tags": [
-        item[0]
-        for item in sorted(
-            fortran_index_tags_data.items(), key=lambda x: x[1], reverse=True
-        )
-        if item[0] != "None" and item[1] > 0
-    ][:50]}
+    tags = {
+        "tags": [
+            item[0]
+            for item in sorted(
+                fortran_index_tags_data.items(), key=lambda x: x[1], reverse=True
+            )
+            if item[0] != "None" and item[1] > 0
+        ][:50]
+    }
     with open(root / "_data" / "fortran_tags.json", "w") as f:
         json.dump(tags, f)
     with open(root / "_data" / "fortran_package.json", "w") as f:

--- a/fortran_package.py
+++ b/fortran_package.py
@@ -1,3 +1,5 @@
+"""Module containing functions specific to the fortran-lang website."""
+
 import yaml
 from pathlib import Path
 from collections import Counter
@@ -18,9 +20,7 @@ def get_contributors(repo: str) -> list[str]:
 
 
 def update_json_files() -> None:
-    """
-    Update the JSON files that define the webpage configuration.
-    """
+    """Update the JSON files that define the webpage configuration."""
     root = Path(__file__).parent
 
     # --- Update references

--- a/fortran_package.py
+++ b/fortran_package.py
@@ -97,7 +97,3 @@ def update_json_files() -> None:
     contributor_repo = {"repo": "fortran-lang", "contributor": contributors}
     with open(root / "_data" / "contributor.json", "w") as f:
         json.dump(contributor_repo, f)
-
-
-if __name__ == "__main__":
-    update_json_files()

--- a/intl.py
+++ b/intl.py
@@ -17,7 +17,6 @@ You can also pass the language code as an argument:
 
 Do not pass the default language code as an argument.
 """
-# pylint: disable=invalid-name,import-error
 
 import sys
 import subprocess
@@ -36,18 +35,6 @@ srcdir = root / "source"
 
 localedir = root / "locale"
 """Path to the locale directory."""
-
-all_languages: List[str]
-"""
-List of currently supported languages, taken from ``_data/languages.yml``.
-
-To support a new language add its `language code`_ to the list.
-
-.. _language code: https://www.sphinx-doc.org/en/master/usage/configuration.html#intl-options
-"""
-
-with open(root / "data" / "languages.yml", "r", encoding="utf-8") as fd:
-    all_languages = list(yaml.safe_load(fd).values())
 
 
 def intl_gettext() -> None:
@@ -94,6 +81,17 @@ def intl_all(languages: List[str]) -> None:
 
 
 if __name__ == "__main__":
+    all_languages: List[str]
+    """
+    List of currently supported languages, taken from ``_data/languages.yml``.
+
+    To support a new language add its `language code`_ to the list.
+
+    .. _language code: https://www.sphinx-doc.org/en/master/usage/configuration.html#intl-options
+    """
+
+    with open(root / "data" / "languages.yml", "r", encoding="utf-8") as fd:
+        all_languages = list(yaml.safe_load(fd).values())
     intl_all(sys.argv[1:] if len(sys.argv) > 1 else all_languages[1:])
 
     print()

--- a/source/conf.py
+++ b/source/conf.py
@@ -241,10 +241,10 @@ def generate_package_pages(app, config):
     env = Environment(loader=loader)
 
     # Configure packages
-    template_path = os.path.join("_templates/package.md")
+    template_path = pathlib.Path("_templates", "package.md")
     out_dir = os.path.join(app.srcdir, "packages")
     os.makedirs(out_dir, exist_ok=True)
-    template = env.get_template(template_path)
+    template = env.get_template(str(template_path))
 
     # Auto-generate the package pages
     for package in package_index:
@@ -260,10 +260,10 @@ def generate_category_pages(app, config):
     env = Environment(loader=loader)
 
     # Configure categories
-    template_path = os.path.join("_templates/category_pages.md")
+    template_path = pathlib.Path("_templates", "category_pages.md")
     out_dir = os.path.join(app.srcdir, "categories")
     os.makedirs(out_dir, exist_ok=True)
-    template = env.get_template(template_path)
+    template = env.get_template(str(template_path))
 
     # Auto-generate the category pages
     for tag in fortran_packages.keys():

--- a/source/conf.py
+++ b/source/conf.py
@@ -238,38 +238,45 @@ tags_page_title = "Tags"
 tags_page_header = "Packages with this tag"
 
 
-def generate_package_and_category_pages(app, config):
-    """Generate per-package and per-category pages from templates."""
+def generate_package_pages(app, config):
+    """Generate per-package pages from templates."""
+    loader = FileSystemLoader(app.srcdir)
+    env = Environment(loader=loader)
 
     # Configure packages
     template_path = os.path.join("_templates/package.md")
     out_dir = os.path.join(app.srcdir, "packages")
     os.makedirs(out_dir, exist_ok=True)
-    loader = FileSystemLoader(app.srcdir)
-    env = Environment(loader=loader)
     template = env.get_template(template_path)
 
     # Auto-generate the package pages
     for package in package_index:
         content = template.render(package=package)
-
         stub = re.sub(r"[^a-z0-9]+", "-", package["name"].lower()).strip("-")
         with open(os.path.join(out_dir, f"{stub}.md"), "w") as f:
             f.write(content)
+
+
+def generate_category_pages(app, config):
+    """Generate per-category and tag pages from templates."""
+    loader = FileSystemLoader(app.srcdir)
+    env = Environment(loader=loader)
 
     # Configure categories
     template_path = os.path.join("_templates/category_pages.md")
     out_dir = os.path.join(app.srcdir, "categories")
     os.makedirs(out_dir, exist_ok=True)
-
-    # Auto-generate tags
     template = env.get_template(template_path)
+
+    # Auto-generate the category pages
     for tag in fortran_packages.keys():
         content = template.render(
             title=fortran_categories[tag]["title"],
             description=fortran_categories[tag]["description"],
             items=fortran_packages[tag],
         )
+
+        # Auto-generate tag pages
         with open(os.path.join(out_dir, f"{tag}.md"), "w") as f:
             f.write(content)
 
@@ -277,5 +284,6 @@ def generate_package_and_category_pages(app, config):
 def setup(app):
     """Drive the Sphinx build."""
 
-    # Config stage
-    app.connect("config-inited", generate_package_and_category_pages)
+    # Tasks to run once config has been initialised
+    app.connect("config-inited", generate_package_pages)
+    app.connect("config-inited", generate_category_pages)

--- a/source/conf.py
+++ b/source/conf.py
@@ -1,10 +1,10 @@
-# Configuration file for the Sphinx documentation builder.
-#
-# This file only contains a selection of the most common options. For a full
-# list see the documentation:
-# https://www.sphinx-doc.org/en/master/usage/configuration.html
 """
 Fortran-lang webpage configuration file.
+
+This configuration file is for the Sphinx documentation builder.
+
+For information on the format, see
+https://www.sphinx-doc.org/en/master/usage/configuration.html
 """
 
 # -- Imports -----------------------------------------------------------------

--- a/source/conf.py
+++ b/source/conf.py
@@ -18,11 +18,13 @@ Fortran-lang webpage configuration file.
 # import os
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
+from jinja2 import Environment, FileSystemLoader
 import json
-import yaml
-import sys
+import os
 import pathlib
-
+import re
+import sys
+import yaml
 
 root = pathlib.Path(__file__).parent.parent
 
@@ -237,9 +239,6 @@ tags_extension = ["md"]
 tags_page_title = "Tags"
 tags_page_header = "Packages with this tag"
 
-import os
-from jinja2 import Environment, FileSystemLoader
-import re
 
 def generate_package_and_category_pages(app, config):
     """Generate per-package and per-category pages from templates."""

--- a/source/conf.py
+++ b/source/conf.py
@@ -210,19 +210,19 @@ if not all(data.exists() for data in data_files.values()):
     update_json_files()
 
 # Read data from the files that were generated above if not already present
-with open(data_files["fortran-learn"], "r", encoding="utf-8") as f:
+with data_files["fortran-learn"].open() as f:
     conf = json.load(f)
-with open(data_files["fortran-packages"], "r", encoding="utf-8") as f:
+with data_files["fortran-packages"].open() as f:
     fortran_packages = json.load(f)
-with open(data_files["fortran-tags"], "r", encoding="utf-8") as f:
+with data_files["fortran-tags"].open() as f:
     fortran_tags = json.load(f)
-with open(data_files["contributors"], "r", encoding="utf-8") as f:
+with data_files["contributors"].open() as f:
     contributors = json.load(f)
-with open(data_files["fortran-categories"], "r", encoding="utf-8") as f:
+with data_files["fortran-categories"].open() as f:
     fortran_categories = yaml.safe_load(f)
-with open(data_files["intrinsics"], "r", encoding="utf-8") as f:
+with data_files["intrinsics"].open() as f:
     intrinsics = yaml.safe_load(f)
-with open(data_files["package-index"], "r", encoding="utf-8") as f:
+with data_files["package-index"].open() as f:
     package_index = yaml.safe_load(f)
 
 jinja_contexts = {

--- a/source/conf.py
+++ b/source/conf.py
@@ -7,8 +7,6 @@
 Fortran-lang webpage configuration file.
 """
 
-# pylint: disable=invalid-name, redefined-builtin
-
 # -- Path setup --------------------------------------------------------------
 
 # If extensions (or modules to document with autodoc) are in another directory,
@@ -244,8 +242,8 @@ def generate_package_and_category_pages(app, config):
     """Generate per-package and per-category pages from templates."""
 
     # Configure packages
-    template_path = os.path.join('_templates/package.md')
-    out_dir = os.path.join(app.srcdir, 'packages')
+    template_path = os.path.join("_templates/package.md")
+    out_dir = os.path.join(app.srcdir, "packages")
     os.makedirs(out_dir, exist_ok=True)
     loader = FileSystemLoader(app.srcdir)
     env = Environment(loader=loader)
@@ -254,20 +252,24 @@ def generate_package_and_category_pages(app, config):
     # Auto-generate the package pages
     for package in package_index:
         content = template.render(package=package)
-        
-        stub = re.sub(r'[^a-z0-9]+', '-', package["name"].lower()).strip('-')
+
+        stub = re.sub(r"[^a-z0-9]+", "-", package["name"].lower()).strip("-")
         with open(os.path.join(out_dir, f"{stub}.md"), "w") as f:
             f.write(content)
 
     # Configure categories
-    template_path = os.path.join('_templates/category_pages.md')
-    out_dir = os.path.join(app.srcdir, 'categories')
+    template_path = os.path.join("_templates/category_pages.md")
+    out_dir = os.path.join(app.srcdir, "categories")
     os.makedirs(out_dir, exist_ok=True)
 
     # Auto-generate tags
     template = env.get_template(template_path)
     for tag in fortran_packages.keys():
-        content = template.render(title=fortran_categories[tag]["title"], description=fortran_categories[tag]["description"], items=fortran_packages[tag])
+        content = template.render(
+            title=fortran_categories[tag]["title"],
+            description=fortran_categories[tag]["description"],
+            items=fortran_packages[tag],
+        )
         with open(os.path.join(out_dir, f"{tag}.md"), "w") as f:
             f.write(content)
 

--- a/source/conf.py
+++ b/source/conf.py
@@ -7,15 +7,8 @@
 Fortran-lang webpage configuration file.
 """
 
-# -- Path setup --------------------------------------------------------------
+# -- Imports -----------------------------------------------------------------
 
-# If extensions (or modules to document with autodoc) are in another directory,
-# add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
-#
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
 from jinja2 import Environment, FileSystemLoader
 import json
 import os
@@ -24,41 +17,12 @@ import re
 import sys
 import yaml
 
+# Project-specific imports
 root = pathlib.Path(__file__).parent.parent
-
-data_files = {
-    "fortran-learn": pathlib.Path(root, "_data", "fortran_learn.json"),
-    "fortran-packages": pathlib.Path(root, "_data", "fortran_package.json"),
-    "fortran-tags": pathlib.Path(root, "_data", "fortran_tags.json"),
-    "contributors": pathlib.Path(root, "_data", "contributor.json"),
-    "package-index": pathlib.Path(root, "data", "package_index.yml"),
-    "fortran-categories": pathlib.Path(root, "data", "categories.yml"),
-    "intrinsics": pathlib.Path(root, "data", "intrinsics.yml"),
-}
-
 sys.path.insert(0, str(root / "extensions"))
+sys.path.insert(0, str(root.absolute()))
+from fortran_package import update_json_files
 
-if not all(data.exists() for data in data_files.values()):
-    sys.path.insert(0, str(root.absolute()))
-    from fortran_package import update_json_files
-
-    update_json_files()
-
-with open(data_files["fortran-learn"], "r", encoding="utf-8") as f:
-    conf = json.load(f)
-with open(data_files["fortran-packages"], "r", encoding="utf-8") as f:
-    fortran_packages = json.load(f)
-with open(data_files["fortran-tags"], "r", encoding="utf-8") as f:
-    fortran_tags = json.load(f)
-with open(data_files["contributors"], "r", encoding="utf-8") as f:
-    contributors = json.load(f)
-
-with open(data_files["fortran-categories"], "r", encoding="utf-8") as f:
-    fortran_categories = yaml.safe_load(f)
-with open(data_files["intrinsics"], "r", encoding="utf-8") as f:
-    intrinsics = yaml.safe_load(f)
-with open(data_files["package-index"], "r", encoding="utf-8") as f:
-    package_index = yaml.safe_load(f)
 
 # -- Project information -----------------------------------------------------
 
@@ -118,15 +82,6 @@ if language == "en":
 exclude_patterns = ["learn/intrinsics/_pages/*.md"]
 html_additional_pages = {}
 suppress_warnings = ["myst.header"]
-
-jinja_contexts = {
-    "conf": conf,
-    "fortran_index": fortran_packages,
-    "tags": fortran_tags,
-    "categories": {"categories": fortran_categories},
-    "contributors": contributors,
-    "intrinsics": intrinsics,
-}
 
 
 # -- Options for HTML output -------------------------------------------------
@@ -236,6 +191,48 @@ tags_create_badges = True
 tags_extension = ["md"]
 tags_page_title = "Tags"
 tags_page_header = "Packages with this tag"
+
+
+# -- Load jinja contexts from file -------------------------------------------
+
+data_files = {
+    "fortran-learn": pathlib.Path(root, "_data", "fortran_learn.json"),
+    "fortran-packages": pathlib.Path(root, "_data", "fortran_package.json"),
+    "fortran-tags": pathlib.Path(root, "_data", "fortran_tags.json"),
+    "contributors": pathlib.Path(root, "_data", "contributor.json"),
+    "package-index": pathlib.Path(root, "data", "package_index.yml"),
+    "fortran-categories": pathlib.Path(root, "data", "categories.yml"),
+    "intrinsics": pathlib.Path(root, "data", "intrinsics.yml"),
+}
+
+# Regenerate data files if required
+if not all(data.exists() for data in data_files.values()):
+    update_json_files()
+
+# Read data from the files that were generated above if not already present
+with open(data_files["fortran-learn"], "r", encoding="utf-8") as f:
+    conf = json.load(f)
+with open(data_files["fortran-packages"], "r", encoding="utf-8") as f:
+    fortran_packages = json.load(f)
+with open(data_files["fortran-tags"], "r", encoding="utf-8") as f:
+    fortran_tags = json.load(f)
+with open(data_files["contributors"], "r", encoding="utf-8") as f:
+    contributors = json.load(f)
+with open(data_files["fortran-categories"], "r", encoding="utf-8") as f:
+    fortran_categories = yaml.safe_load(f)
+with open(data_files["intrinsics"], "r", encoding="utf-8") as f:
+    intrinsics = yaml.safe_load(f)
+with open(data_files["package-index"], "r", encoding="utf-8") as f:
+    package_index = yaml.safe_load(f)
+
+jinja_contexts = {
+    "conf": conf,
+    "fortran_index": fortran_packages,
+    "tags": fortran_tags,
+    "categories": {"categories": fortran_categories},
+    "contributors": contributors,
+    "intrinsics": intrinsics,
+}
 
 
 def generate_package_pages(app, config):

--- a/source/conf.py
+++ b/source/conf.py
@@ -241,17 +241,18 @@ import os
 from jinja2 import Environment, FileSystemLoader
 import re
 
-
-## generate per-package and per-category pages from templates
 def generate_package_and_category_pages(app, config):
+    """Generate per-package and per-category pages from templates."""
+
+    # Configure packages
     template_path = os.path.join('_templates/package.md')
     out_dir = os.path.join(app.srcdir, 'packages')
     os.makedirs(out_dir, exist_ok=True)
-    
     loader = FileSystemLoader(app.srcdir)
     env = Environment(loader=loader)
     template = env.get_template(template_path)
 
+    # Auto-generate the package pages
     for package in package_index:
         content = template.render(package=package)
         
@@ -259,16 +260,21 @@ def generate_package_and_category_pages(app, config):
         with open(os.path.join(out_dir, f"{stub}.md"), "w") as f:
             f.write(content)
 
+    # Configure categories
     template_path = os.path.join('_templates/category_pages.md')
     out_dir = os.path.join(app.srcdir, 'categories')
     os.makedirs(out_dir, exist_ok=True)
 
+    # Auto-generate tags
     template = env.get_template(template_path)
     for tag in fortran_packages.keys():
         content = template.render(title=fortran_categories[tag]["title"], description=fortran_categories[tag]["description"], items=fortran_packages[tag])
-        
         with open(os.path.join(out_dir, f"{tag}.md"), "w") as f:
             f.write(content)
 
+
 def setup(app):
+    """Drive the Sphinx build."""
+
+    # Config stage
     app.connect("config-inited", generate_package_and_category_pages)


### PR DESCRIPTION
This PR refactors all Python files in the repo (except for the Playground):
* Code that was executed in the main body of files has been moved into functions or `if __name__ == "__main__"` blocks, where possible.
* Comments and docstrings for clarity.
* Dropped unused variables and redundant functions.
* General formatting.
* Updates and misc improvements to the README.

Hopefully these changes will accelerate progress in future Fortran index hackathons.