### PR TITLE
Documentation: add & move packages and rename section in  package index

### DIFF
--- a/data/package_index.yml
+++ b/data/package_index.yml
@@ -363,7 +363,7 @@
   github: sourceryinstitute/OpenCoarrays
   description: A parallel runtime library using MPI to support gfortran's multi-image features
   categories: libraries
-  tags: mpi gfortran
+  tags: mpi gfortran parallel-runtime-library
 
 - name: Caffeine
   github: berkeleylab/caffeine

--- a/data/package_index.yml
+++ b/data/package_index.yml
@@ -59,12 +59,6 @@
   categories: libraries
   tags: string date time graphics command-line posix ncurses sqlite regex
 
-- name: Open Coarrays
-  github: sourceryinstitute/OpenCoarrays
-  description: A parallel application binary interface for Fortran 2018 compilers
-  categories: libraries
-  tags: mpi openshmem gfortran
-
 - name: FLAP
   github: szaghi/FLAP
   description: Fortran command Line Arguments Parser
@@ -356,7 +350,7 @@
   tags: cpp c python julia matlab rust mpi
   license: LGPL-3.0
 
-# --- Compiler
+# --- Compilers and runtime libraries
 
 - name: hipfort
   github: ROCmSoftwarePlatform/hipfort
@@ -364,6 +358,19 @@
   categories: programming
   tags: hip rocm
   license: MITx11
+
+- name: OpenCoarrays
+  github: sourceryinstitute/OpenCoarrays
+  description: A parallel runtime library using MPI to support gfortran's multi-image features
+  categories: libraries
+  tags: mpi gfortran
+
+- name: Caffeine
+  github: berkeleylab/caffeine
+  description: A parallel runtime library using GASNet-EX to support compilers' multi-image features via the Parallel Runtime Interface for Fortran (PRIF)
+  categories: libraries
+  tags: parallel-runtime-library prif llvm-flang lfortran gasnet
+  license: BSD-3-Clause
 
 # --- Programming utilities ---
 
@@ -531,6 +538,13 @@
   categories: programming
   tags: parser
   license: MIT
+
+- name: julienne
+  github: berkeleylab/julienne
+  description: A correctness-checking framework supporting natural-language idioms for unit testing and assertions; also facilitating formatted diagnostic output during error termination in pure procedures
+  categories: programming
+  tags: unit-testing assertions pure-procedure-diagnostic-output
+  license: BSD-3-Clause
 
 # --- Data types ---
 
@@ -1206,6 +1220,13 @@
   categories: numerical
   tags: automatic-differentiation adjoint algorithmic derivative AD autodiff jacobian hessian
   license: MIT
+
+- name: formal
+  github: berkeleylab/formal
+  description: Formulaic mimetic abstraction language
+  categories: numerical
+  tags: partial-differential-equations domain-specific-language mimetic-discretizations
+  license: BSD-3-Clause
 
 # --- Scientific codes ---
 


### PR DESCRIPTION
This PR
1. Replaces `# --- Compiler` with `# --- Compilers and runtime libraries`
2. Moves OpenCoarrays to `# --- Compilers and runtime libraries`
3. Adds the Berkeley Lab packages:
   - Caffeine under `# --- Compilers and runtime libraries`
   - Formal under `# --- Numerical`
   - Julienne under `# --- Programming utilities`