### PR TITLE
Add Enzyme to package index

### DIFF
--- a/data/package_index.yml
+++ b/data/package_index.yml
@@ -449,9 +449,9 @@
 
 - name: Tapenade
   url: https://gitlab.inria.fr/tapenade/tapenade
-  description: A tool for automatic differentiation (forward/reverse) of Fortran and c programs
+  description: A tool for automatic differentiation (forward/reverse) of Fortran and C programs
   categories: programming numerical
-  tags: algorithmic derivative ad
+  tags: automatic-differentiation
   license: MIT
   version: 3.16-v2
 
@@ -459,9 +459,16 @@
   github: Nicholaswogan/Differentia
   description: Computes derivatives, gradients and Jacobians of Fortran functions/subroutines using forward automatic differentiation.
   categories: programming numerical
-  tags: algorithmic derivative AD autodiff
+  tags: automatic-differentiation
   license: MIT
   version: 0.1.4
+
+- name: Enzyme
+  github: EnzymeAD/Enzyme
+  description: High-performance automatic differentiation of LLVM and MLIR with bindings for Fortran and other languages
+  categories: programming
+  tags: automatic-differentiation llvm-flang
+  license: Apache-2.0 with LLVM exceptions
 
 - name: camfort
   github: camfort/camfort
@@ -1232,7 +1239,7 @@
   github: nedtaylor/diffstruc
   description: A library providing a derived type that enables forward and reverse mode automatic differentiation.
   categories: numerical
-  tags: automatic-differentiation adjoint algorithmic derivative AD autodiff jacobian hessian
+  tags: automatic-differentiation adjoint
   license: MIT
 
 - name: formal


### PR DESCRIPTION
This PR adds the [Enzyme](https://github.com/EnzymeAD/Enzyme) automatic differentiation (AD) tool to the package index, which we recently added Fortran bindings for.

The PR also improves the consistency of the listing for other AD packages.