### PR TITLE
Add fitpack, fortran-lapack, fortran-bessels, fortran-regex, fortran-shlex and fortran-fast-float

### DIFF
--- a/data/package_index.yml
+++ b/data/package_index.yml
@@ -736,7 +736,7 @@
   github: perazz/fortran-fast-float
   description: Modern Fortran implementation of the fast_float library for exact, high-performance string-to-number parsing
   categories: strings io
-  tags: floating-point eisel-lemire conversion performance
+  tags: floating-point conversion performance
   license: "MIT OR Apache-2.0 OR BSL-1.0"
 
 # --- File input / output ---

--- a/data/package_index.yml
+++ b/data/package_index.yml
@@ -1306,7 +1306,7 @@
   github: perazz/fitpack
   description: A Modern Fortran translation of the FITPACK package for curve and surface fitting
   categories: numerical
-  tags: splines interpolation smoothing knots object-oriented
+  tags: splines interpolation smoothing object-oriented
   license: BSD-3-Clause
 
 - name: fortran-bessels

--- a/data/package_index.yml
+++ b/data/package_index.yml
@@ -718,6 +718,27 @@
   tags: pcre pcre2 regex
   license: ISC
 
+- name: fortran-regex
+  github: perazz/fortran-regex
+  description: A Modern Fortran port of the tiny-regex-c library for regular expressions
+  categories: strings
+  tags: regex pattern-matching
+  license: MIT
+
+- name: fortran-shlex
+  github: perazz/fortran-shlex
+  description: Modern Fortran port of Python's shlex shell-like lexer, with Windows mslex support
+  categories: strings programming
+  tags: command-line tokenizer quoting posix mslex
+  license: MIT
+
+- name: fortran-fast-float
+  github: perazz/fortran-fast-float
+  description: Modern Fortran implementation of the fast_float library for exact, high-performance string-to-number parsing
+  categories: strings io
+  tags: floating-point eisel-lemire conversion performance
+  license: "MIT OR Apache-2.0 OR BSL-1.0"
+
 # --- File input / output ---
 
 - name: atomsk
@@ -1273,6 +1294,27 @@
   categories: numerical
   tags: partial-differential-equations domain-specific-language mimetic-discretizations
   license: BSD-3-Clause
+
+- name: fortran-lapack
+  github: perazz/fortran-lapack
+  description: Precision-agnostic, high-level linear algebra APIs backed by a Modern Fortran implementation of Reference-LAPACK
+  categories: numerical
+  tags: lapack blas eigenvalues singular-values matrix-factorization linear-equations least-squares
+  license: BSD-3-Clause
+
+- name: fitpack
+  github: perazz/fitpack
+  description: A Modern Fortran translation of the FITPACK package for curve and surface fitting
+  categories: numerical
+  tags: splines interpolation smoothing knots object-oriented
+  license: BSD-3-Clause
+
+- name: fortran-bessels
+  github: perazz/fortran-bessels
+  description: A Modern Fortran port of the Bessels.jl library for fast and accurate Bessel function evaluation
+  categories: numerical
+  tags: special-functions elemental math
+  license: MIT
 
 # --- Scientific codes ---
 


### PR DESCRIPTION
Adds six Modern Fortran packages to the package index.

**Numerical libraries**

| Package | Description | License |
| --- | --- | --- |
| [fortran-lapack](https://github.com/perazz/fortran-lapack) | Precision-agnostic, high-level linear algebra APIs backed by a Modern Fortran implementation of Reference-LAPACK | BSD-3-Clause |
| [fitpack](https://github.com/perazz/fitpack) | A Modern Fortran translation of the FITPACK package for curve and surface fitting | BSD-3-Clause |
| [fortran-bessels](https://github.com/perazz/fortran-bessels) | A Modern Fortran port of the Bessels.jl library for fast and accurate Bessel function evaluation | MIT |

**Strings**

| Package | Description | Categories |
| --- | --- | --- |
| [fortran-regex](https://github.com/perazz/fortran-regex) | A Modern Fortran port of the tiny-regex-c library for regular expressions | `strings` |
| [fortran-shlex](https://github.com/perazz/fortran-shlex) | Modern Fortran port of Python's shlex shell-like lexer, with Windows mslex support | `strings programming` |
| [fortran-fast-float](https://github.com/perazz/fortran-fast-float) | Modern Fortran implementation of the fast_float library for exact, high-performance string-to-number parsing | `strings io` |
