### PR TITLE
Add forformat to package index

### DIFF
--- a/data/package_index.yml
+++ b/data/package_index.yml
@@ -530,6 +530,13 @@
   license: BSD-3-Clause
   version: 3.1.7
 
+- name: forformat
+  github: cmbant/forformat
+  description: Fortran indenter and formatter with spacing and case consistency
+  categories: programming
+  tags: findent
+  license: BSD-3-Clause
+
 - name: fprettify
   github: pseewald/fprettify
   description: auto-formatter for modern fortran source code


### PR DESCRIPTION
## Summary

Add [[forformat](https://github.com/cmbant/forformat)](https://github.com/cmbant/forformat) to the Fortran-lang package index alongside `findent`, `fprettify`, and `ffmt`.

`forformat` is a standalone formatter for free-form Fortran. It provides findent-compatible indentation together with lexical normalization, identifier case consistency, statement wrapping, project-aware formatting, and check/diff modes.

It is implemented in Rust, with Python wheels available from PyPI, and also supports pre-commit and editor integration.

## Package details

* Repository: https://github.com/cmbant/forformat
* Category: `programming`
* License: BSD-3-Clause
* PyPI: https://pypi.org/project/forformat/
* Documentation and usage examples are included in the repository.

The project is relatively new and does not yet have the suggested five GitHub stars. However, the main functionality is implemented and released, with CI, tests, packaged releases, user documentation, and compatibility/migration documentation for users of `findent`.