### PR TITLE
Add a Ruff lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,56 @@
+# Github action to lint and format-check the Python sources with Ruff
+#
+#  Runs on pull requests and on pushes to main, but only when something it
+#  could possibly complain about has changed.
+#
+
+name: Lint
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "**/*.py"
+      - ".pre-commit-config.yaml"
+      - ".github/workflows/lint.yml"
+  pull_request:
+    paths:
+      - "**/*.py"
+      - ".pre-commit-config.yaml"
+      - ".github/workflows/lint.yml"
+
+# A second push to the same branch makes the first run's answer worthless, so
+# stop it rather than pay for it twice.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# Reads the source and reports; it never needs to write anything back.
+permissions: {}
+
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout page source
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      # Pinned to the version .pre-commit-config.yaml already uses, so a
+      # contributor whose hooks pass cannot be failed here by a newer Ruff.
+      # Upgrading Ruff means changing both this pin and the hook's rev.
+      - name: Lint with Ruff
+        uses: astral-sh/ruff-action@v4.1.0
+        with:
+          version: 0.15.6
+          args: check --output-format=github
+
+      - name: Check formatting with Ruff
+        uses: astral-sh/ruff-action@v4.1.0
+        with:
+          version: 0.15.6
+          args: format --check --diff

--- a/source/conf.py
+++ b/source/conf.py
@@ -21,7 +21,7 @@ import yaml
 root = pathlib.Path(__file__).parent.parent
 sys.path.insert(0, str(root / "extensions"))
 sys.path.insert(0, str(root.absolute()))
-from fortran_package import update_json_files
+from fortran_package import update_json_files  # noqa: E402  (needs sys.path above)
 
 
 # -- Project information -----------------------------------------------------


### PR DESCRIPTION
Closes #678.

`.pre-commit-config.yaml` already runs `ruff-check` and `ruff-format`, but
nothing enforces them on a pull request, so a contributor who has not installed
the hooks can merge unlinted Python. This adds the missing CI job.

I followed the [green-ci](https://github.com/Cambridge-ICCS/green-ci)
conventions you linked in the issue:

- **`permissions: {}`** — the job reads the source and reports. It never needs
  to write anything back.
- **`concurrency` with `cancel-in-progress`** — a second push to a branch makes
  the first run's answer worthless, so it stops rather than being paid for
  twice.
- **Path filters** — most changes to this repo are not Python, and the job does
  not run on them.
- **`timeout-minutes: 5`**.

One choice that is not from the template: **Ruff is pinned to `0.15.6`, the same
revision `.pre-commit-config.yaml` uses.** If CI floats to latest it will
eventually fail contributors whose local hooks pass, on a rule they had no way
to run. Pinning to the hook means bumping the hook is the single place that
moves both. Happy to switch to `latest` if you would rather CI lead the hook.

### One suppression was needed

`ruff check` currently reports exactly one error:

```
source/conf.py:24:1: E402 Module level import not at top of file
   |
24 | from fortran_package import update_json_files
```

That import has to come after the two `sys.path.insert` calls above it — that is
what puts `fortran_package` on the path at all — so the rule cannot be satisfied
by reordering. I silenced it on the line with the reason attached rather than
adding a per-file ignore, which would have dropped every other check on
`conf.py`.

`ruff format --check` was already clean on all five files, so the formatting
step should stay green from the first run.
