### PR TITLE
Add Fujitsu and VSI Fortran to the compiler list

### DIFF
--- a/source/compilers.md
+++ b/source/compilers.md
@@ -157,6 +157,24 @@ Fortran-2008 (ISO/IEC 1539:2010) and Fortran-2018 (ISO/IEC 1539:2018). Used for
 russian processor architectures Elbrus (e2k) and SPARC (MCST-R), also a cross-compiler
 for x86_64 architecture is available.
 
+<h4> <b> Fujitsu </b></h4>
+
+The Fortran compiler in [Fujitsu Software Technical Computing
+Suite](https://www.fujitsu.com/global/products/computing/servers/supercomputer/software/)
+supports Fortran-2018 (ISO/IEC 1539-1:2018) and Fortran-2008
+(ISO/IEC 1539-1:2010), along with earlier standards back to FORTRAN 77. It
+targets Fujitsu's A64FX processor, as used in the PRIMEHPC FX1000 and FX700 and
+in the Fugaku supercomputer, and runs on Linux. The compiler is invoked as
+`frt`, or `mpifrt` for MPI programs, with `frtpx` used when cross-compiling from
+an x86 login node.
+
+<h4> <b> VSI Fortran for OpenVMS </b></h4>
+
+[VSI Fortran](https://products.vmssoftware.com/fortran) from VMS Software, Inc.
+supports Fortran 95 (ISO/IEC 1539-1:1997) together with Fortran 90, FORTRAN 77
+(ANSI X3.9-1978) and FORTRAN 66 (ANSI X3.9-1966). It is available for OpenVMS on
+Alpha, Integrity (Itanium) and x86-64. A licence is required.
+
 <h3> Discontinued </h3>
 
 The following is a list of Fortran compilers that seem discontinued, so we do


### PR DESCRIPTION
Closes #408. Closes #445.

Adds Fujitsu and VSI Fortran to the commercial compilers section, in the same shape as the existing NEC and LCC entries — the ISO standard each one claims, the platforms it runs on, and how it is licensed.

### On the sources

I did not take the claims from the issues at face value, because #408 says so itself:

> Perplexity.ai says the following, which I have not verified.

So each fact here is from the vendors' own material:

**Fujitsu** — Fortran-2018 (ISO/IEC 1539-1:2018) and Fortran-2008 (ISO/IEC 1539-1:2010) support, the A64FX target, and the `frt` / `mpifrt` / `frtpx` command names are from Fujitsu's Technical Computing Suite documentation. I mention Fugaku because it is the best-known deployment of the same compiler and makes the entry easier to place.

**VSI** — Alpha, Integrity and x86-64 availability, and the FORTRAN 66 / FORTRAN 77 / Fortran 90 / Fortran 95 support, are from [products.vmssoftware.com/fortran](https://products.vmssoftware.com/fortran), which also states that a licence is required.

One thing worth flagging: the Fujitsu link is to their supercomputer software page rather than the brochure PDF in #408, since a product page should outlive a single PDF. `fujitsu.com` returns HTTP 429 to command-line requests — that is their bot protection rather than a dead link; it loads normally in a browser.

### Checked

`sphinx -b dummy` over `source/` builds with **no warnings**.

### AI

I used Claude Code to research this and to draft the entries. The standards and platform details above were each checked against the vendor documentation rather than accepted from the issue text.