### PR TITLE
Adding blog for gathering legacy fortran patterns

### DIFF
--- a/source/_static/news.css
+++ b/source/_static/news.css
@@ -1,0 +1,107 @@
+.legacy-patterns-container {
+  display: grid;
+  grid-template-columns: minmax(0, 700px) auto;
+  gap: 1rem 1.5rem;
+  margin: 2rem 0;
+  align-items: end;
+}
+
+.submit-box {
+  max-width: 700px;
+  padding: 1.5rem;
+  border-radius: 8px;
+  border: 1px solid rgba(63, 94, 138, 0.35);
+  background: rgba(255,255,255,0.03);
+}
+
+.submit-box label {
+  display: block;
+  margin: 0.9rem 0 0.35rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.submit-box label:first-child {
+  margin-top: 0;
+}
+
+.submit-box label span {
+  color: #b54a3a;
+}
+
+.submit-box label .optional {
+  color: inherit;
+  font-size: 0.8rem;
+  font-weight: 400;
+  opacity: 0.65;
+}
+
+.submit-helper {
+  margin: 0.8rem 0 0;
+  font-size: 0.88rem;
+  line-height: 1.5;
+  opacity: 0.72;
+}
+
+.tip-input,
+.tip-textarea {
+
+  width: 100%;
+  padding: 0.85rem 1rem;
+  margin-bottom: 0.5rem;
+  border-radius: 6px;
+  border: 1px solid rgba(255,255,255,0.12);
+  background: rgba(255,255,255,0.04);
+  font-size: 0.95rem;
+  font-family: inherit;
+  transition:
+    border-color 0.2s ease,
+    background 0.2s ease;
+}
+
+.tip-textarea {
+  min-height: 7rem;
+  resize: vertical;
+}
+
+.tip-input:focus,
+.tip-textarea:focus {
+  outline: 2px solid #6FA8FF;
+  outline-offset: 1px;
+  background: rgba(255,255,255,0.06);
+}
+
+.tip-submit-btn {
+  margin-top: 0;
+  border: none;
+  border-radius: 6px;
+  padding: 0.85rem 1.2rem;
+  background: #3F5E8A;
+  color: white;
+  font-family: inherit;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    background 0.2s ease,
+    transform 0.2s ease;
+}
+
+.tip-submit-btn:hover {
+
+  background: #5377AA;
+  transform: translateY(-1px);
+}
+
+@media (max-width: 600px) {
+
+  .legacy-patterns-container {
+    display: block;
+  }
+
+  .tip-submit-btn {
+    margin-top: 0.5rem;
+    width: 100%;
+  }
+}
+

--- a/source/conf.py
+++ b/source/conf.py
@@ -96,7 +96,7 @@ html_show_sourcelink = False
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
-html_css_files = ["custom.css"]
+html_css_files = ["custom.css","news.css"]
 html_canonical_url = None
 
 favicons = [

--- a/source/news/2026/08-09-legacy-code-confessions.md
+++ b/source/news/2026/08-09-legacy-code-confessions.md
@@ -1,0 +1,136 @@
+---
+category: blogpost
+date: 2026-09-08
+author: Andrew Brown, Connor Aird, <Everyone from our group>
+...
+
+<script>
+function submitTip(event) {
+  event.preventDefault();
+
+  const form = event.target;
+  const fields = {
+    pattern: form.elements.pattern.value.trim(),
+    problem: form.elements.problem.value.trim(),
+    alternative: form.elements.alternative.value.trim(),
+    context: form.elements.context.value.trim()
+  };
+  const issueTitle = `[Legacy Fortran pattern] ${fields.pattern}`;
+  const issueBody = `## Pattern to avoid
+${fields.pattern}
+
+## Why it causes trouble
+${fields.problem}
+
+## Better alternative or mitigation
+${fields.alternative}
+
+## Context
+${fields.context || "Not provided"}`;
+  const url =
+    "<repo-url>/issues/new"
+    + "?labels=legacy-fortran"
+    + "&title=" + encodeURIComponent(issueTitle)
+    + "&body=" + encodeURIComponent(issueBody);
+
+  window.open(url, "_blank");
+}
+</script>
+
+# Legacy Code Confessions
+
+Legacy Fortran is full of code that works, has survived for decades, and is
+difficult to change. We are collecting the patterns that make legacy
+systems harder to understand, test, maintain, or modernise, together with the
+practical alternatives that helped.
+
+This is not about blaming the people who wrote the code. Constraints change,
+and many of these choices were reasonable at the time. The goal is to give the
+next developer a map: what to recognise, why it is risky, and where to start
+improving it.
+
+If you are some knowledge to share please continue reading and contribute today!
+
+## What makes a useful contribution?
+
+Tell us about one specific pattern. It might be a language feature, an
+interface convention, a build or testing practice, or an organisational habit
+around a codebase. The most useful reports include:
+
+* The pattern, described plainly enough that someone can recognise it;
+* The failure mode: what makes it hard to work with or easy to get wrong;
+* A better alternative, a mitigation, or a safe first step; and
+* Context such as a Fortran standard, compiler, tool or domain.
+
+For example, "passing array dimensions as unrelated integer arguments" is more
+useful than "bad interfaces". Explain that mismatched dimensions can compile
+and corrupt results, then suggest assumed-shape dummy arguments with explicit
+interfaces, or a smaller mitigation when a full refactor is not yet possible.
+
+## Share a pattern
+
+Submit one pattern at a time. You do not need to name a person or organisation,
+and please remove proprietary or confidential details. Your submission will
+open as a GitHub issue so the curriculum team can discuss, edit, and review it
+before anything is published.
+
+<div class="legacy-patterns-container">
+  <form class="submit-box" onsubmit="submitTip()">
+    <label for="tip-pattern">Pattern to avoid <span>*</span></label>
+    <input
+      class="tip-input"
+      id="tip-pattern"
+      name="pattern"
+      required
+      placeholder="e.g. Global state hidden in COMMON blocks"
+    />
+    <label for="tip-problem">Why does it cause trouble? <span>*</span></label>
+    <textarea
+      class="tip-textarea"
+      id="tip-problem"
+      name="problem"
+      required
+      placeholder="What makes the code hard to understand, test, or change?"
+    ></textarea>
+    <label for="tip-alternative">Better alternative or mitigation <span>*</span></label>
+    <textarea
+      class="tip-textarea"
+      id="tip-alternative"
+      name="alternative"
+      required
+      placeholder="What would you recommend, and what is a realistic first step?"
+    ></textarea>
+    <label for="tip-context">Context <span class="optional">optional</span></label>
+    <textarea
+      class="tip-textarea"
+      id="tip-context"
+      name="context"
+      placeholder="Fortran standard, compiler, domain, toolchain, or code age"
+    ></textarea>
+    <p class="submit-helper">
+      Required fields are marked *. Do not include confidential code or details
+      that identify individuals.
+    </p>
+    <button class="tip-submit-btn" type="submit">Open a GitHub issue</button>
+  </form>
+</div>
+
+## Learn more
+
+This project grew from the fourth [Back to the Fortran Future](https://fortran-lang.org/news/2026/05-05-Back-to-the-Fortran-Future-3/)
+workshop, held as a satellite event to the [10th annual Research Software
+Engineering Conference](https://rsecon26.society-rse.org/) in Sheffield on 8
+September 2026. The workshop brought together people working on one of
+Fortran's persistent challenges: developers inheriting large, important
+codebases without the context needed to maintain them confidently.
+
+One outcome will be a practical guide for developers who need to understand and
+modernise legacy Fortran. We also want the resulting entries to be structured
+enough for tools and AI assistants to use responsibly: a recognisable pattern,
+its consequences, and advice grounded in real experience. [Share a pattern
+above](#share-a-pattern) to help build that resource.
+
+This guide will live in the [Software Carpentries
+Incubator](https://carpentries-incubator.github.io/legacy-fortran/), and may
+grow into a dedicated Carpentries-style workshop linked to the larger [Fortran
+Carpentries curriculum](https://carpentries-incubator.github.io/intro-to-modern-fortran/profiles.html#pathways).

--- a/source/news/2026/08-09-legacy-code-confessions.md
+++ b/source/news/2026/08-09-legacy-code-confessions.md
@@ -10,25 +10,38 @@ function submitTip(event) {
 
   const form = event.target;
   const fields = {
-    pattern: form.elements.pattern.value.trim(),
-    problem: form.elements.problem.value.trim(),
-    alternative: form.elements.alternative.value.trim(),
-    context: form.elements.context.value.trim()
+    summary: form.elements.summary.value.trim(),
+    smell: form.elements.smell.value.trim(),
+    benefits: form.elements.benefits.value.trim(),
+    example: form.elements.example.value.trim(),
+    solution: form.elements.solution.value.trim()
   };
-  const issueTitle = `[Legacy Fortran pattern] ${fields.pattern}`;
-  const issueBody = `## Pattern to avoid
-${fields.pattern}
+  const issueTitle = `[Community Proposed pattern] ${fields.summary}`;
+  const issueBody = `## Short summary of the pattern
 
-## Why it causes trouble
-${fields.problem}
+${fields.summary}
 
-## Better alternative or mitigation
-${fields.alternative}
+## Code smells
 
-## Context
-${fields.context || "Not provided"}`;
+${fields.smell}
+
+## Benefits of removing the code smell
+
+${fields.benefits}
+
+## Example showing the pattern
+
+\`\`\`fortran
+${fields.example}
+\`\`\`
+
+## Updated example
+
+${fields.solution ? `\`\`\`fortran
+${fields.solution}
+\`\`\`` : "Not provided"}`;
   const url =
-    "<repo-url>/issues/new"
+    "https://github.com/carpentries-incubator/legacy-fortran/issues/new"
     + "?labels=legacy-fortran"
     + "&title=" + encodeURIComponent(issueTitle)
     + "&body=" + encodeURIComponent(issueBody);
@@ -40,76 +53,93 @@ ${fields.context || "Not provided"}`;
 # Legacy Code Confessions
 
 Legacy Fortran is full of code that works, has survived for decades, and is
-difficult to change. We are collecting the patterns that make legacy
-systems harder to understand, test, maintain, or modernise, together with the
-practical alternatives that helped.
+difficult to change. Despite their success, these legacy systems can be hard to
+understand, test, maintain, or modernise. To help, we are collecting the
+patterns that give legacy systems these qualities, together with tried and
+tested the alternatives that can help.
 
 This is not about blaming the people who wrote the code. Constraints change,
 and many of these choices were reasonable at the time. The goal is to give the
 next developer a map: what to recognise, why it is risky, and where to start
 improving it.
 
-If you are some knowledge to share please continue reading and contribute today!
+If you have knowledge to share, please continue reading and contribute today!
 
 ## What makes a useful contribution?
 
-Tell us about one specific pattern. It might be a language feature, an
-interface convention, a build or testing practice, or an organisational habit
-around a codebase. The most useful reports include:
+Tell us about one specific pattern. This won't necessarily be a bug and the
+code may still appear to work. These patterns can usually be identified through
+their [code smells](https://en.wikipedia.org/wiki/Code_smell) that hint at
+deeper design or maintainability problems; It might involve a language feature,
+a build or testing practice, or an organisational habit around a codebase. The
+most useful reports include:
 
-* The pattern, described plainly enough that someone can recognise it;
-* The failure mode: what makes it hard to work with or easy to get wrong;
-* A better alternative, a mitigation, or a safe first step; and
-* Context such as a Fortran standard, compiler, tool or domain.
+* A short summary naming the pattern.
+* The code smells that help a developer identify the issue;
+* The benefits of moving away from this pattern;
+* A small example showing the pattern; and
+* An updated code example showing the solution.
 
-For example, "passing array dimensions as unrelated integer arguments" is more
-useful than "bad interfaces". Explain that mismatched dimensions can compile
-and corrupt results, then suggest assumed-shape dummy arguments with explicit
-interfaces, or a smaller mitigation when a full refactor is not yet possible.
+For example, the short summary could be "Break large procedures into smaller
+units". The code smells might be that Multiple dummy arguments are updated in a
+single procedure (i.e. many intent(out) arguments) or simply that a line of
+code is deeply indented. The benefits could include that procedures with only
+one purpose are much easier to unit test as well as being easier to fix should
+a bug be introduced. A small example can show the original procedure updating
+multiple dummy arguments, followed by an updated set of multiple procedures for
+each task.
 
 ## Share a pattern
 
-Submit one pattern at a time. You do not need to name a person or organisation,
-and please remove proprietary or confidential details. Your submission will
-open as a GitHub issue so the curriculum team can discuss, edit, and review it
-before anything is published.
+Submit one pattern at a time. You should not name any individual or
+organisation, and please remove proprietary or confidential details. Your
+submission will open as a GitHub issue so the curriculum team can discuss,
+edit, and review it before anything is published.
 
 <div class="legacy-patterns-container">
-  <form class="submit-box" onsubmit="submitTip()">
-    <label for="tip-pattern">Pattern to avoid <span>*</span></label>
+  <form class="submit-box" onsubmit="submitTip(event)">
+    <label for="tip-summary">Short summary of the problem <span>*</span></label>
     <input
       class="tip-input"
-      id="tip-pattern"
-      name="pattern"
+      id="tip-summary"
+      name="summary"
       required
       placeholder="e.g. Global state hidden in COMMON blocks"
     />
-    <label for="tip-problem">Why does it cause trouble? <span>*</span></label>
+    <label for="tip-smell">Code smell <span>*</span></label>
     <textarea
       class="tip-textarea"
-      id="tip-problem"
-      name="problem"
+      id="tip-smell"
+      name="smell"
       required
-      placeholder="What makes the code hard to understand, test, or change?"
+      placeholder="What recognisable sign helps a developer identify this issue?"
     ></textarea>
-    <label for="tip-alternative">Better alternative or mitigation <span>*</span></label>
+    <label for="tip-benefits">Benefits of removing the code smell <span>*</span></label>
     <textarea
       class="tip-textarea"
-      id="tip-alternative"
-      name="alternative"
+      id="tip-benefits"
+      name="benefits"
       required
-      placeholder="What would you recommend, and what is a realistic first step?"
+      placeholder="How will the code become easier to understand, test, maintain, or change?"
     ></textarea>
-    <label for="tip-context">Context <span class="optional">optional</span></label>
+    <label for="tip-example">Small example showing the pattern <span>*</span></label>
     <textarea
-      class="tip-textarea"
-      id="tip-context"
-      name="context"
-      placeholder="Fortran standard, compiler, domain, toolchain, or code age"
+      class="tip-textarea tip-code"
+      id="tip-example"
+      name="example"
+      required
+      placeholder="Paste a small, self-contained Fortran example"
+    ></textarea>
+    <label for="tip-solution">Updated code showing the solution <span class="optional">optional</span></label>
+    <textarea
+      class="tip-textarea tip-code"
+      id="tip-solution"
+      name="solution"
+      placeholder="Show the same example after removing the code smell"
     ></textarea>
     <p class="submit-helper">
-      Required fields are marked *. Do not include confidential code or details
-      that identify individuals.
+      Required fields are marked *. Keep examples small and remove confidential
+      code or details that identify individuals.
     </p>
     <button class="tip-submit-btn" type="submit">Open a GitHub issue</button>
   </form>
@@ -117,9 +147,10 @@ before anything is published.
 
 ## Learn more
 
-This project grew from the fourth [Back to the Fortran Future](https://fortran-lang.org/news/2026/05-05-Back-to-the-Fortran-Future-3/)
-workshop, held as a satellite event to the [10th annual Research Software
-Engineering Conference](https://rsecon26.society-rse.org/) in Sheffield on 8
+This project grew from the fourth
+[Back to the Fortran Future](https://rsecon26.society-rse.org/satellite-events/back-to-the-fortran-future-4/)
+workshop, held as a satellite event to the
+[10th annual Research Software Engineering Conference](https://rsecon26.society-rse.org/) in Sheffield on 8
 September 2026. The workshop brought together people working on one of
 Fortran's persistent challenges: developers inheriting large, important
 codebases without the context needed to maintain them confidently.
@@ -127,10 +158,10 @@ codebases without the context needed to maintain them confidently.
 One outcome will be a practical guide for developers who need to understand and
 modernise legacy Fortran. We also want the resulting entries to be structured
 enough for tools and AI assistants to use responsibly: a recognisable pattern,
-its consequences, and advice grounded in real experience. [Share a pattern
-above](#share-a-pattern) to help build that resource.
+the benefits of its removal, and examples grounded in real experience.
+[Share a code smell above](#share-a-pattern) to help build this resource.
 
-This guide will live in the [Software Carpentries
-Incubator](https://carpentries-incubator.github.io/legacy-fortran/), and may
-grow into a dedicated Carpentries-style workshop linked to the larger [Fortran
-Carpentries curriculum](https://carpentries-incubator.github.io/intro-to-modern-fortran/profiles.html#pathways).
+This guide will live in the
+[Software Carpentries Incubator](https://carpentries-incubator.github.io/legacy-fortran/),
+and may grow into a dedicated Carpentries-style workshop linked to the larger
+[Fortran Carpentries curriculum](https://carpentries-incubator.github.io/intro-to-modern-fortran/profiles.html#pathways).


### PR DESCRIPTION
# Description

Following on from the Back to the Fortran Future 4 workshop at RSECon26 in Sheffield, this new page aims to gather expertise from the Fortran community about how to work with legacy Fortran and begin refactoring towards better modern Fortran. 

This page includes a form which links to the new [Legacy Fortran carpentries incubator lesson repo](https://github.com/carpentries-incubator/legacy-fortran) to create community suggested patterns as issues.